### PR TITLE
Multipart Requests cause JS Error

### DIFF
--- a/wdn/templates_3.0/scripts/wdn_ajax.js
+++ b/wdn/templates_3.0/scripts/wdn_ajax.js
@@ -138,7 +138,7 @@ var getProxyClass = function( s, jqXHR ) {
 			
 			if (total > 1) {
 				for (var i = 0; i < total; i++) {
-					request.push(jQuery.param({
+					requests.push(jQuery.param({
 						mp: total,
 						mo: i,
 						c: jsonpCallback,


### PR DESCRIPTION
Low priority bug fix that restores the ability to make multipart proxy requests.
