### PR TITLE
Use the new secondary colors for zen harmony.

### DIFF
--- a/wdn/templates_3.1/less/_mixins/zen.less
+++ b/wdn/templates_3.1/less/_mixins/zen.less
@@ -1,43 +1,42 @@
-// legacy "Zen" colors
-@zenBright: #f5e62f;
-@zenCool: #557BB7;
-@zenSoothing: #028a02;
-@zenEnergetic: #FA6520;
+// legacy "Zen" color
 @zenNeutral: #3c3c3c;
-@zenPrimary: #c20403;
 
 .zen-bright()
 {
-    color: darken(@baseText, 10%);
-    .linear-gradient-2-stop(@zenBright, 70%, desaturate(@zenBright, 30%), 100%);
+    color: darken(@colorManilla, 60%);
+    .linear-gradient-2-stop(@colorManilla, 80%, desaturate(@colorManilla, 30%), 100%);
+    text-shadow: (1px 1px 1px lighten(@colorManilla, 20%));
 }
 
 .zen-cool()
 {
-    color: #fff;
-    .linear-gradient-2-stop(@zenCool, 70%, desaturate(@zenCool, 30%), 100%);
+    color: darken(@colorTriad, 60%);
+    .linear-gradient-2-stop(@colorTriad, 80%, desaturate(@colorTriad, 30%), 100%);
+    text-shadow: (1px 1px 1px lighten(@colorTriad, 20%));
 }
 
 .zen-soothing() 
 {
-    color: #fff;
-    .linear-gradient-2-stop(@zenSoothing, 70%, desaturate(@zenSoothing, 50%), 100%);
+    color: darken(@colorComplementary, 50%);
+    .linear-gradient-2-stop(@colorComplementary, 80%, desaturate(@colorComplementary, 30%), 100%);
+    text-shadow: (1px 1px 1px lighten(@colorComplementary, 20%));
 }
 
 .zen-energetic() 
 {
-    color: #fff;
-    .linear-gradient-2-stop(@zenEnergetic, 70%, desaturate(@zenEnergetic, 30%), 100%);
+    .zen-bright();
 }
 
 .zen-neutral() 
 {
     color: #fff;
-    .linear-gradient-2-stop(@zenNeutral, 70%, lighten(@zenNeutral, 15%), 100%);
+    .linear-gradient-2-stop(@zenNeutral, 80%, darken(@zenNeutral, 10%), 100%);
+    text-shadow: (1px 1px 1px darken(@zenNeutral, 20%));
 }
 
 .zen-primary() 
 {
     color: #fff;
-    .linear-gradient-2-stop(@zenPrimary, 70%, desaturate(@zenPrimary, 50%), 100%);
+    .linear-gradient-2-stop(@colorPrimary, 80%, desaturate(@colorPrimary, 50%), 100%);
+    text-shadow: (1px 1px 1px darken(@colorPrimary, 20%));
 }

--- a/wdn/templates_3.1/less/content/zenbox.less
+++ b/wdn/templates_3.1/less/content/zenbox.less
@@ -6,7 +6,7 @@
 * ---------------------------
 * Styles associated with the zenboxes
 * ---------------------------
-*/
+*/ 
 @import "../_mixins/all.less";
 
 #maincontent {

--- a/wdn/templates_3.1/less/content/zentable.less
+++ b/wdn/templates_3.1/less/content/zentable.less
@@ -47,13 +47,13 @@
         }
         
         tr:nth-child(odd) td {
-            background-color: hsl(hue(@zenBright), 100%, 94%);
+            background-color: hsl(hue(@colorManilla), 80%, 94%);
         }
         
         td {
             border-bottom-style: solid;
             border-bottom-width: 1px;
-            border-color: hsl(hue(@zenBright), 100%, 78%);
+            border-color: hsl(hue(@colorManilla), 80%, 78%);
         }
     }
     
@@ -67,10 +67,10 @@
         }
         tbody {
             td {
-                border-color: hsl(hue(@zenCool), 62%, 78%);
+                border-color: hsl(hue(@colorTriad), 62%, 78%);
             }
             tr:nth-child(odd) td {
-                background-color: hsl(hue(@zenCool), 100%, 97%);
+                background-color: hsl(hue(@colorTriad), 100%, 97%);
             }
         }
     }
@@ -84,27 +84,10 @@
         }
         tbody {
             td {
-                border-color: hsl(hue(@zenSoothing), 62%, 78%);
+                border-color: hsl(hue(@colorComplementary), 62%, 78%);
             }
             tr:nth-child(odd) td {
-                background-color: hsl(hue(@zenSoothing), 100%, 97%);
-            }
-        }
-    }
-    &.energetic {
-        /* Energetic Zentable */
-        tr th {
-            .zen-energetic();
-            a {
-                color: #fff;
-            }
-        }
-        tbody {
-            td {
-                border-color: hsl(hue(@zenEnergetic), 100%, 78%);
-            }
-            tr:nth-child(odd) td {
-                background-color: hsl(hue(@zenEnergetic), 100%, 94%);
+                background-color: hsl(hue(@colorComplementary), 100%, 97%);
             }
         }
     }
@@ -135,10 +118,10 @@
         }
         tbody {
             td {
-                border-color: hsl(hue(@zenPrimary), 62%, 78%);
+                border-color: hsl(hue(@colorPrimary), 62%, 78%);
             }
             tr:nth-child(odd) td {
-                background-color: hsl(hue(@zenPrimary), 100%, 97%);
+                background-color: hsl(hue(@colorPrimary), 100%, 97%);
             }
         }
     }


### PR DESCRIPTION
Use new colors for background and color functions.
Remove the energetic, it's now the default (no orange secondary color).
Add text shadows to match some of our other styles.
