### PR TITLE
Remove git status from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,6 @@ all:
 	@@echo "Compressing Desktop and Mobile CSS and JS"
 	${COMPRESS}
 	@@echo "Done"
-	@@echo "Running git status"
-	${GIT} status wdn/templates_3.1
-	@@echo "Any modified files are ready to be committed with git commit wdn/templates_3.1"
-	@@echo "Commit compressed files, then run \`make zips\` to update .zip files."
 
 clean:
 	${COMPRESS} clean
@@ -36,9 +32,6 @@ zips:
 	@@echo "Done building the wdn.zip file."
 	${GIT} archive -o downloads/UNLTemplates.zip HEAD Templates sharedcode
 	@@echo "Done building the UNLTemplates.zip file."
-	@@echo "Running git status"
-	${GIT} status *.zip
-	@@echo "Any modified files are ready to be committed with git commit *.zip"
 
 js-plugin: ${JS_PLUGIN}
 


### PR DESCRIPTION
The git status command was used to detect which compressed files were modified.
Now that the compressed files are no longer stored in the repository, this is
no longer needed.

It also complicates the built process as older versions of git return 1 (non-
zero) exit status which prevents later commands from executing.
