### PR TITLE
Wrap OR operand in spaces so doctype is preserved as the first line

### DIFF
--- a/Templates/debug.dwt
+++ b/Templates/debug.dwt
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <!--#include virtual="/wdn/templates_3.1/includes/metanfavico.html" -->
 <!--

--- a/Templates/fixed.dwt
+++ b/Templates/fixed.dwt
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <!--#include virtual="/wdn/templates_3.1/includes/metanfavico.html" -->
 <!--

--- a/Templates/jsp.debug.dwt.jsp
+++ b/Templates/jsp.debug.dwt.jsp
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <jsp:include page="/wdn/templates_3.1/includes/metanfavico.html" />
 <!--

--- a/Templates/jsp.fixed.dwt.jsp
+++ b/Templates/jsp.fixed.dwt.jsp
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <jsp:include page="/wdn/templates_3.1/includes/metanfavico.html" />
 <!--

--- a/Templates/jsp.unlaffiliate.dwt.jsp
+++ b/Templates/jsp.unlaffiliate.dwt.jsp
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <jsp:include page="/wdn/templates_3.1/includes/metanfavico.html" />
 <!--

--- a/Templates/jsp.unlaffiliate_debug.dwt.jsp
+++ b/Templates/jsp.unlaffiliate_debug.dwt.jsp
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <jsp:include page="/wdn/templates_3.1/includes/metanfavico.html" />
 <!--

--- a/Templates/php.debug.dwt.php
+++ b/Templates/php.debug.dwt.php
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <?php virtual("/wdn/templates_3.1/includes/metanfavico.html"); ?>
 <!--

--- a/Templates/php.fixed.dwt.php
+++ b/Templates/php.fixed.dwt.php
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <?php virtual("/wdn/templates_3.1/includes/metanfavico.html"); ?>
 <!--

--- a/Templates/php.unlaffiliate.dwt.php
+++ b/Templates/php.unlaffiliate.dwt.php
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <?php virtual("/wdn/templates_3.1/includes/metanfavico.html"); ?>
 <!--

--- a/Templates/php.unlaffiliate_debug.dwt.php
+++ b/Templates/php.unlaffiliate_debug.dwt.php
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <?php virtual("/wdn/templates_3.1/includes/metanfavico.html"); ?>
 <!--

--- a/Templates/unlaffiliate.dwt
+++ b/Templates/unlaffiliate.dwt
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <!--#include virtual="/wdn/templates_3.1/includes/metanfavico.html" -->
 <!--

--- a/Templates/unlaffiliate_debug.dwt
+++ b/Templates/unlaffiliate_debug.dwt
@@ -4,7 +4,7 @@
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
 <!--[if (gte IE 9)|(gt IEMobile 7) ]><html class="ie" lang="en"><![endif]-->
-<!--[if !(IEMobile)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<!--[if !(IEMobile) | !(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <!--#include virtual="/wdn/templates_3.1/includes/metanfavico.html" -->
 <!--


### PR DESCRIPTION
By wrapping the OR operand in spaces, Dreamweaver template-derived pages will place the InstanceBegin comment in a better location.
Closes #251
