### PR TITLE
Replicate img frame/caption styles for figure/figcaption.

### DIFF
--- a/wdn/templates_3.1/less/content/images.less
+++ b/wdn/templates_3.1/less/content/images.less
@@ -20,26 +20,31 @@
     display: inline-block;
     .box-sizing(border-box);
 }
+.caption() {
+    line-height: normal;
+    text-align: left;
+    color: #444;
+    font-size: 80%;
+}
 
 #maincontent, #footer, #colorbox {
-    img.frame {
+    .frame {
         .figure();
+        
+        figcaption {
+            .caption();
+        }
     }
     
     p.caption {
-        line-height: normal;
         background: #f7f7f7;
         border: 1px solid #DDD;
         border-radius: 3px;
         border-top: none;
         padding: 2px 4px 5px;
-        text-align: left;
-        color: #555;
-        font-size: 80%;
         position: relative;
         margin-top: -16px;
-        z-index: 2; 
-        display: block;
+        z-index: 2;
+        .caption();   
     }
-    
 }


### PR DESCRIPTION
I'd like to propose the supported markup moving forward is the the new HTML5 elements figure/figcaption instead of applying styles to the image and then a paragraph for the caption.
