### PR TITLE
Remove yesprint markup generation from tabs.

### DIFF
--- a/wdn/templates_3.1/scripts/tabs.js
+++ b/wdn/templates_3.1/scripts/tabs.js
@@ -34,16 +34,6 @@ WDN.tabs = (function() {
 		
 		initialize : function() {
 			WDN.log ("tabs JS loaded");
-			
-			// Add yesprint class to list items, to act as a table of contents when printed
-			WDN.jQuery('ul.wdn_tabs:not(.disableSwitching) li').each(function(){
-				var content    = WDN.jQuery(this).children('a').text();
-				var hash_check = WDN.jQuery(this).children('a').attr('href').split('#');
-				if (hash_check.length == 2 && hash_check[1] !== "") {
-					WDN.jQuery('div#'+hash_check[1]).prepend("<h5 class='yesprint'>"+content+"</h5>");
-				}
-				return true;
-			});
 
 			// Set up the event for when a tab is clicked
 			var hashFromTabClick = false,


### PR DESCRIPTION
If developers want a heading to be displayed, they should include
it in their own markup.
