### PR TITLE
Add height property to help all the images in CMS.

### DIFF
--- a/wdn/templates_3.1/less/content/maincontent.less
+++ b/wdn/templates_3.1/less/content/maincontent.less
@@ -72,7 +72,8 @@
     }
     
     img, video, audio, object { 
-        max-width:100%; 
+        max-width:100%;
+        height: auto;
     }
 }
 


### PR DESCRIPTION
CMS inserts width and height attributes into the img element. Setting height to auto will help the resize in many cases.
