### PR TITLE
Add pageview tracking for external links.

### DIFF
--- a/wdn/templates_3.1/scripts/analytics.js
+++ b/wdn/templates_3.1/scripts/analytics.js
@@ -85,6 +85,7 @@ WDN.analytics = function() {
 						//WDN.jQuery(this).addClass('external'); //Implications for doing this?
 						WDN.jQuery(this).click(function() {
 							WDN.analytics.callTrackEvent('Outgoing Link', gahref, WDN.analytics.thisURL);
+							WDN.analytics.callTrackPageview(gahref);
 						});
 					}  
 					else if (gahref.match(/^mailto\:/i)){  //deal with mailto: links


### PR DESCRIPTION
While goals can be setup around events, full goal functionality is still best available when it's used as a page track.
