### PR TITLE
Remove unnecessary vendor prefixes.

### DIFF
--- a/wdn/templates_3.1/less/_mixins/css3.less
+++ b/wdn/templates_3.1/less/_mixins/css3.less
@@ -141,9 +141,6 @@
 
 // background size
 .background-size(@arguments) when (@arguments = cover), (@arguments = contain) {
-    -moz-background-size: @arguments;
-    -o-background-size: @arguments;
-    -webkit-background-size: @arguments;
     background-size: @arguments; 
 }
 .background-size(@arguments) when not (@arguments = cover) and not (@arguments = contain) {
@@ -151,9 +148,6 @@
 }
 
 .background-size(@x, @y) {
-    -moz-background-size: @x @y;
-    -o-background-size: @x @y;
-    -webkit-background-size: @x @y;
     background-size: @x @y;  
 }
 


### PR DESCRIPTION
Many of the CSS3 rules are implemented with the standard property names now, and support for older browsers through vendor-prefixes is no longer needed. Chosen edits were based on:
http://caniuse.com/
http://dochub.io/#css/
