### PR TITLE
Don't try to track GoURL button in analytics. Close #332

### DIFF
--- a/wdn/templates_3.1/scripts/analytics.js
+++ b/wdn/templates_3.1/scripts/analytics.js
@@ -102,7 +102,7 @@ WDN.analytics = function() {
 						});  
 					}  
 				}); 
-				WDN.jQuery('ul.socialmedia a').click(function(){ 
+				WDN.jQuery('.socialmedia .outpost a').click(function(){ 
 					var socialMedia = WDN.jQuery(this).parent().attr('id');
 					socialMedia = socialMedia.replace(/wdn_/gi, '');
 					console.log(socialMedia);


### PR DESCRIPTION
Keep the scope of what we're tracking to just the outpost buttons, as originally intended. This fixes the JS error where analytics was trying to track the GoURL button which doesn't have an ID.
