### PR TITLE
Reference the correct form fields when updating the comment form.

### DIFF
--- a/wdn/templates_3.1/scripts/idm.js
+++ b/wdn/templates_3.1/scripts/idm.js
@@ -191,8 +191,16 @@ WDN.idm = function() {
 		 * Add user details to the comment form
 		 */
 		updateCommentForm : function () {
-			var commentName  = document.getElementById('wdn_comment_name'),
-				commentEmail = document.getElementById('wdn_comment_email');
+			//Determine which comment form we are using. (WDN or the new Chat System).
+			if (document.getElementById('wdn_feedback_comments') != null) {
+				//WDN form
+				var commentName  = document.getElementById('wdn_comment_name'),
+					commentEmail = document.getElementById('wdn_comment_email');
+			}else {
+				//UNL Chat System
+				var commentName  = document.getElementById('visitorChat_name'),
+					commentEmail = document.getElementById('visitorChat_email');
+			}
 		    
 			commentName.value = WDN.idm.displayName();
 		    if (WDN.idm.user.mail) {


### PR DESCRIPTION
The unl chat email form will be replacing the wdn comment form.  Some fields have different ids and thus the idm updateCommentForm() breaks if the wrong form is loaded.  Determine which one is loaded and correctly update fields.
