### PR TITLE
Remove text-stroke due to Chrome rendering change.

### DIFF
--- a/wdn/templates_3.1/less/navigation/navigation.less
+++ b/wdn/templates_3.1/less/navigation/navigation.less
@@ -455,7 +455,8 @@
                     color: rgba(255, 255, 255, 0.99);
                     text-shadow: 1px 1px 1px #424242;
                     font-weight: 500;
-                    -webkit-text-stroke: 0.55px;
+                    // Commented out due to rendering changes in Chrome. @TODO revisit with new release http://code.google.com/p/chromium/issues/detail?id=152304
+                    // -webkit-text-stroke: 0.55px;
                     font-size: 0.875em;
                     margin: auto 0;
                     padding: 0.47em 1px;


### PR DESCRIPTION
See: http://code.google.com/p/chromium/issues/detail?id=152304

Due to recent rendering change in Chrome OSX, the `-webkit-font-smoothing: antialiased` and `-webkit-text-stroke` no longer work together nicely.

It appears Chrome will revert this change (http://code.google.com/p/chromium/issues/detail?id=152304#c83), but until then Safari will have skinny text.
