### PR TITLE
Bugfix 371

### DIFF
--- a/wdn/templates_3.1/scripts/navigation.js
+++ b/wdn/templates_3.1/scripts/navigation.js
@@ -205,7 +205,7 @@ WDN.navigation = (function() {
             }).remove();
             // create the link using whatever the Homepage is set to
             $siteTitle.contents().filter(function() {
-            	return this.nodeType == 3 && this.nodeValue;
+            	return this.nodeType == 3;
             }).first().wrap(WDN.jQuery('<a/>', {href : WDN.navigation.siteHomepage}));
         },
 


### PR DESCRIPTION
Remove the extra text nodes that PHP templates add to the DOM to prevent issues with site title linking.
