### PR TITLE
Remove jQuery reliance for link tracking

### DIFF
--- a/debug.shtml
+++ b/debug.shtml
@@ -83,11 +83,12 @@
             <div id="maincontent">
                 <!--THIS IS THE MAIN CONTENT AREA; WDN: see glossary item 'main content area' -->
                 <!-- InstanceBeginEditable name="maincontentarea" -->
-                  <h2 class="sec_header">Image manipulation test</h2>
-                  <figure class="frame">
-                    <img src="images/test_320.jpg" alt="this is a test image" />
-                    <figcaption>This is a test</figcaption>
-                </figure>
+                  <h2 class="sec_header">GA Tracking Test</h2>
+                  <a href="myfile.pdf">A PDF file</a>
+                  <br />
+                  <a href="http://www.google.com/" onclick="return false;">Another site</a>
+                  <br />
+                  <a href="mailto:bob@aol.com">An email link</a>
                   <!-- InstanceEndEditable -->
                 <div class="clear"></div>
                 <!--#include virtual="/wdn/templates_3.1/includes/noscript.html" -->

--- a/wdn/templates_3.1/scripts/analytics.js
+++ b/wdn/templates_3.1/scripts/analytics.js
@@ -23,12 +23,12 @@ WDN.analytics = function() {
 		rated : false, // whether the user has rated the current page.
 		initialize : function() {
 			var widthScript = WDN.getCurrentWidthScript(), isMobile = widthScript == '320';
-			WDN.log("WDN site analytics loaded for "+ WDN.analytics.thisURL);
+			WDN.log("WDN site analytics loaded for "+ WDN.analytics.thisURL) ;
 
             var version_html = WDN.getHTMLVersion(),
                 version_dep  = WDN.getDepVersion(),
                 ga_linkattribution_pluginURL = '//www.google-analytics.com/plugins/ga/inpage_linkid.js';
-			
+
 			_gaq.push(
 				['wdn._setAccount', 'UA-3203435-1'],
 				['wdn._setDomainName', '.unl.edu'],
@@ -37,7 +37,7 @@ WDN.analytics = function() {
 				['wdn._setAllowLinker', true],
 				['wdn._require', 'inpage_linkid', ga_linkattribution_pluginURL]
 			);
-			
+
 			if (isMobile) {
 				_gaq.push(
 					['m._setAccount', 'UA-3203435-4'],
@@ -48,7 +48,7 @@ WDN.analytics = function() {
 					['m._require', 'inpage_linkid', ga_linkattribution_pluginURL]
 				);
 			}
-			
+
 			if (!initd['desktop'] && !initd['mobile']) {
 				WDN.loadJS(WDN.getTemplateFilePath('scripts/idm.js'), function(){
 					WDN.idm.initialize(function() {
@@ -56,34 +56,9 @@ WDN.analytics = function() {
 					});
 				});
 			}
-			
-			if (!isMobile && !initd['desktop']) {	
-				//TODO: Remove jQuery from the events below
-				
-				filetypes = /\.(zip|exe|pdf|doc*|xls*|ppt*|mp3|m4v|mov|mp4)$/i; //these are the file extensions to track for downloaded content
-				WDN.jQuery('#navigation a[href], #maincontent a[href]').each(function(){  
-					var gahref = WDN.jQuery(this).attr('href');
-					if ((gahref.match(/^https?\:/i)) && (!gahref.match(document.domain))){  //deal with the outbound links
-						//WDN.jQuery(this).addClass('external'); //Implications for doing this?
-						WDN.jQuery(this).click(function() {
-							WDN.analytics.callTrackEvent('Outgoing Link', gahref, WDN.analytics.thisURL);
-							WDN.analytics.callTrackPageview(gahref);
-						});
-					}  
-					else if (gahref.match(/^mailto\:/i)){  //deal with mailto: links
-						WDN.jQuery(this).click(function() {  
-							var mailLink = gahref.replace(/^mailto\:/i, '');  
-							WDN.analytics.callTrackEvent('Email', mailLink, WDN.analytics.thisURL);
-						});  
-					}  
-					else if (gahref.match(filetypes)){  //deal with file downloads
-						WDN.jQuery(this).click(function() { 
-							var extension = (/[.]/.exec(gahref)) ? /[^.]+$/.exec(gahref) : undefined;
-							WDN.analytics.callTrackEvent('File Download', gahref, WDN.analytics.thisURL); 
-							WDN.analytics.callTrackPageview(gahref);
-						});  
-					}  
-				}); 
+
+			if (!isMobile && !initd['desktop']) {
+				/* At >768, we bring in .socialmedia and #wdn_toollinks and .rating, so keep using jQuery for these. */
 				WDN.jQuery('.socialmedia .outpost a').click(function(){ 
 					var socialMedia = WDN.jQuery(this).parent().attr('id');
 					socialMedia = socialMedia.replace(/wdn_/gi, '');
@@ -117,6 +92,56 @@ WDN.analytics = function() {
 			} else {
 				initd['mobile'] = true;
 			}
+			
+			WDN.analytics.bindLinks();
+		},
+		
+		bindLinks : function() {
+            WDN.log('Begin binding links for analytics');
+            //get the links in the navigation and maincontent
+            var nav = document.getElementById('navigation'), navLinks = nav.getElementsByTagName("a"), main = document.getElementById('maincontent'), mainLinks = main.getElementsByTagName("a"), evaluateLinks, filetypes = /\.(zip|exe|pdf|doc*|xls*|ppt*|mp3|m4v|mov|mp4)$/i;
+            
+            evaluateLinks = function(link) {
+                var gahref = link.getAttribute("href");
+                if (!gahref) {
+                    return;
+                }
+
+                function bindEvent(el, eventName, eventHandler) {
+                    if (el.addEventListener){
+                        el.addEventListener(eventName, eventHandler, false); 
+                    } else if (el.attachEvent){
+                        el.attachEvent('on'+eventName, eventHandler);
+                    }
+                }
+ 
+                if ((gahref.match(/^https?\:/i)) && (!gahref.match(document.domain))){
+                    bindEvent(link, 'click', function() {
+                        WDN.analytics.callTrackEvent('Outgoing Link', gahref, WDN.analytics.thisURL);
+                        WDN.analytics.callTrackPageview(gahref);
+                    });
+                } else if (gahref.match(/^mailto\:/i)){
+                    var mailLink = gahref.replace(/^mailto\:/i, '');  
+                    bindEvent(link, 'click', function() {
+                        WDN.analytics.callTrackEvent('Email', mailLink, WDN.analytics.thisURL);
+                    });
+                } else if (gahref.match(filetypes)){
+                    var extension = (/[.]/.exec(gahref)) ? /[^.]+$/.exec(gahref) : undefined;
+                    bindEvent(link, 'click', function() {
+                        WDN.analytics.callTrackEvent('File Download', gahref, WDN.analytics.thisURL);
+                        WDN.analytics.callTrackPageview(gahref);
+                    });
+                }
+            }
+
+            //loop through all the links and pass them to type evaluation
+            for (var i=0; i<navLinks.length; i++) {
+                evaluateLinks(navLinks[i]);
+            }
+            
+            for (var j=0; j<mainLinks.length; j++) {
+                evaluateLinks(mainLinks[j]);
+            }
 		},
 		
 		loadGA : function(mobile){


### PR DESCRIPTION
A new version of the closed #312. Using @kabel's recommendation for `eventListener` instead of `onclick`s.
