### PR TITLE
Stronger, more flexible selector

### DIFF
--- a/wdn/templates_3.1/less/content/grid-v3.less
+++ b/wdn/templates_3.1/less/content/grid-v3.less
@@ -47,10 +47,12 @@
 }
 
 // reset for list grids
-#maincontent ul, ol {
-    &.[class*="wdn-grid-set"] {
-        padding-left: 0;
-        list-style: none;
+#maincontent {
+    ul, ol {
+        &.[class*="wdn-grid-set"] {
+            padding-left: 0;
+            list-style: none;
+        }
     }
 }
 


### PR DESCRIPTION
- Overpower base `ul` & `ol` Layouts
- Use `class` attribute for broader coverage
