### PR TITLE
Don't track external link as `pageview` in WDN analytics.

### DIFF
--- a/wdn/templates_3.1/scripts/analytics.js
+++ b/wdn/templates_3.1/scripts/analytics.js
@@ -118,7 +118,7 @@ WDN.analytics = function() {
                 if ((gahref.match(/^https?\:/i)) && (!gahref.match(document.domain))){
                     bindEvent(link, 'click', function() {
                         WDN.analytics.callTrackEvent('Outgoing Link', gahref, WDN.analytics.thisURL);
-                        WDN.analytics.callTrackPageview(gahref);
+                        WDN.analytics.callTrackPageview(gahref, false);
                     });
                 } else if (gahref.match(/^mailto\:/i)){
                     var mailLink = gahref.replace(/^mailto\:/i, '');  
@@ -168,7 +168,10 @@ WDN.analytics = function() {
 			} catch(e){}
 		},
 		
-		callTrackPageview: function(thePage){
+		callTrackPageview: function(thePage, trackInWDNAccount){
+            if (trackInWDNAccount === undefined) {
+                trackInWDNAccount = true;
+            }
 			var widthScript = WDN.getCurrentWidthScript();
 			WDN.log('we can now track the page');
 			if (!thePage) {
@@ -178,11 +181,13 @@ WDN.analytics = function() {
 				}
 				return;
 			}
-			_gaq.push(['wdn._trackPageview', thePage]); //First, track in the wdn analytics
-			if (widthScript == '320') {
-				_gaq.push(['m._trackPageview', thePage]);
+			if (trackInWDNAccount) {
+    			_gaq.push(['wdn._trackPageview', thePage]); //First, track in the wdn analytics
+    			if (widthScript == '320') {
+    				_gaq.push(['m._trackPageview', thePage]);
+    			}
+    			WDN.log("Pageview tracking for wdn worked!");
 			}
-			WDN.log("Pageview tracking for wdn worked!");
 			try {
 				if (WDN.analytics.isDefaultTrackerReady()) {
 					_gaq.push(['_trackPageview', thePage]); // Second, track in local site analytics 


### PR DESCRIPTION
# More Information

In many cases, a link to an external site is causing the "page" to be tracked twice in the global, WDN analytics.
## Example

Take the link http://cas.unl.edu/ as an example from the UNL homepage. By tracking this external link as a faux-pageview, it was being tracked once when the link was clicked, but then tracked again when the browser rendered the CAS homepage.
## Other Issues to Consider

This removes the ability to tie goal funnels to the use of these external links. Originally, the only way to tie goals to external links was through this faux-pageview tracking. Recent updates to Google Analytics allow events -- _which do not have the ability to tie funnels_ -- to be be used in goals. For all scenarios related to the WDN goal tracking this is satisfactory.

This does **not** remove the ability for local sites to track these faux-pageviews. This issue of double-tracking is not prevalent in individual local sites.
