### PR TITLE
Destroy the unl_sso global cookie if the user's CAS session has ended

### DIFF
--- a/wdn/templates_3.1/scripts/idm.js
+++ b/wdn/templates_3.1/scripts/idm.js
@@ -81,6 +81,8 @@ WDN.idm = (function() {
 						};
 						WDN.idm.displayNotice(WDN.idm.getUserId());
 					} else {
+						// User's CAS session is no longer active, kill cookie
+						WDN.idm.logout();
 						loginCheckFailure();
 					}
 				});


### PR DESCRIPTION
Currently the unl_sso cookie sticks around until the browser's session has ended. This change removes the cookie if the whoami server fails to return correct IDM information, which is an indication that the CAS single-sign-on session has ended.
