### PR TITLE
Add more specificity to bare .first rule in v2 grid

### DIFF
--- a/wdn/templates_4.0/less/layouts/old-grid.less
+++ b/wdn/templates_4.0/less/layouts/old-grid.less
@@ -153,12 +153,12 @@
         .thisWidth(11);
     }
 
-    [class^="grid"] .first {
-        margin-left: 0 !important;
-    }
-
-    .first {
+    [class^="grid"].first {
         margin-left: ~'-webkit-calc(50% - 480px)' !important;
         margin-left: ~'calc(50% - 480px)' !important;
+    }
+
+    [class^="grid"] .first {
+        margin-left: 0 !important;
     }
 }


### PR DESCRIPTION
The bare .first rule causes a lot of problems in Drupal which uses first as a class everywhere.

I hope this is a working solution to preface it so it only applies to grid.
