### PR TITLE
Add clear:both to .wdn-band

### DIFF
--- a/wdn/templates_4.0/less/layouts/bands.less
+++ b/wdn/templates_4.0/less/layouts/bands.less
@@ -6,7 +6,8 @@
 
 .wdn-band {
     max-width: 100% !important; //important is required to overpower the wildcard selector above
-    
+    clear: both;
+
     #maincontent > *& {
         padding: 0;
     }
@@ -17,7 +18,7 @@
         #maincontent & {
             padding: 1em 5px;
         }
-        
+
         @media @bp3 {
             #maincontent & {
                 padding: 1em 0;
@@ -54,7 +55,7 @@
             margin: 0 auto;
         }
     }
-    
+
     .wdn-text-band {
 
         .wdn-inner-wrapper {


### PR DESCRIPTION
Adding this to avoid any unexpected funny business where a band follows something floated. 
