### PR TITLE
Update tabs.js to better support dynamically adding tabs.

### DIFF
--- a/wdn/templates_3.1/scripts/tabs.js
+++ b/wdn/templates_3.1/scripts/tabs.js
@@ -43,7 +43,7 @@ WDN.tabs = (function() {
 			var hashFromTabClick = false,
 				$tabsWithSwitch = WDN.jQuery('ul.wdn_tabs').not('.disableSwitching');
 			
-			$tabsWithSwitch.find('a').click(function() { //do something when a tab is clicked
+			$tabsWithSwitch.on('click', 'a', function() { //do something when a tab is clicked
 				var trig = WDN.jQuery(this),
 					hash = getHashFromLink(this);
 				


### PR DESCRIPTION
I'd like to be able to dynamically add tabs to a page.  Right now, the click() handler is only applied to tabs that exist when the tabs are initialized.  By moving the handler from the a node to the ul node, any tabs added later should work just fine.
