### PR TITLE
Notices

### DIFF
--- a/wdn/templates_4.0/less/modules/notices.less
+++ b/wdn/templates_4.0/less/modules/notices.less
@@ -31,6 +31,7 @@
     border: 1px solid @dark-triad;
     margin-bottom: 10px;
     border-radius: 3px;
+    padding: 8px;
 
     #maincontent > & {
         padding: 8px;


### PR DESCRIPTION
- css padding bug fix using !important for conflicts when a notice is an immediate child of #maincontent
- soften padding and border-radius to make notices lean and sexy and bring them in line with other elements like tabs and buttons

Before:
![screen shot 2013-08-14 at 4 21 13 pm](https://f.cloud.github.com/assets/446357/965332/a05c096a-0528-11e3-95a2-398363cb2b2c.png)

After:
![screen shot 2013-08-14 at 4 26 36 pm](https://f.cloud.github.com/assets/446357/965334/aadef6e0-0528-11e3-93d0-1ff31ef76425.png)

Problem when notice is immediate child of maincontent - look at left padding next to checkmark:
![screen shot 2013-08-14 at 4 31 13 pm](https://f.cloud.github.com/assets/446357/965349/f3fbbf8e-0528-11e3-8e74-a84f6c7a168c.png)
