### PR TITLE
Cange `wdn-inner-wrapper` to use max-wdith

### DIFF
--- a/wdn/templates_4.0/less/layouts/bands.less
+++ b/wdn/templates_4.0/less/layouts/bands.less
@@ -51,7 +51,7 @@
     .wdn-band {
 
         .wdn-inner-wrapper {
-            width: 60rem;
+            max-width: 60rem;
             margin: 0 auto;
         }
     }


### PR DESCRIPTION
setting the width to 60 was causing content to overflow into other grid columns.  see https://github.com/unlcms/unl_four/issues/4

I'm not sure if this would cause any negative side effects.  Thoughts/suggestions anyone?
