### PR TITLE
Improve button UI for interaction states (active/down, focus, disabled)

### DIFF
--- a/wdn/templates_4.0/less/modules/forms.less
+++ b/wdn/templates_4.0/less/modules/forms.less
@@ -5,8 +5,17 @@
     &:hover {
         background-color: darken(@color, 7%);
     }
+    
+    &:focus {
+    	outline: thin dotted @color;
+    }
+    
+    &:active {
+    	background-color: @color;
+    }
 
     &[disabled] {
+    	cursor: not-allowed;
         background-color: mix(@color, #666666, 45%);
         color: darken(#FFFFFF, 10%);
         .box-shadow(0 2px 0px mix(@color, #666666, 30%));


### PR DESCRIPTION
Due to the "stately" nature of these changes, a screen-shot of these changes won't suffice.

This pull adds
- the standard "focus" state indicator of a dotted outline (in the button's color).
- an "active" (or down) state that overrides the hover state -- perhaps this can be further improved.
- a cursor indicator for disabled buttons
