### PR TITLE
wdn-clear class added to clear wdn-cols

### DIFF
--- a/wdn/templates_4.0/less/layouts/grid.less
+++ b/wdn/templates_4.0/less/layouts/grid.less
@@ -12,27 +12,28 @@
     }
 
     &.wdn-grid-clear {
-        &[class*="-halves"] [class*="wdn-col"]:nth-of-type(2n+1) {
+
+        &.@{grid-set}-halves .@{grid-col-class}:nth-child(2n+1) {
             clear:left;
         }
 
-        &[class*="-thirds"] [class*="wdn-col"]:nth-of-type(3n+1) {
+        &.@{grid-set}-thirds .@{grid-col-class}:nth-child(3n+1) {
             clear:left;
         }
 
-        &[class*="-fourths"] [class*="wdn-col"]:nth-of-type(4n+1) {
+        &.@{grid-set}-fourths .@{grid-col-class}:nth-child(4n+1) {
             clear:left;
         }
 
-        &[class*="-fifths"] [class*="wdn-col"]:nth-of-type(5n+1) {
+        &.@{grid-set}-fifths .@{grid-col-class}:nth-child(5n+1) {
             clear:left;
         }
 
-        &[class*="-sixths"] [class*="wdn-col"]:nth-of-type(6n+1) {
+        &.@{grid-set}-sixths .@{grid-col-class}:nth-child(6n+1) {
             clear:left;
         }
 
-        &[class*="-sevenths"] [class*="wdn-col"]:nth-of-type(7n+1) {
+        &.@{grid-set}-sevenths .@{grid-col-class}:nth-child(7n+1) {
             clear:left;
         }
     }


### PR DESCRIPTION
By adding a class to the grid-set to clear wdn-cols.  This will clear each additional "row" of wdn-cols. 

example of class naming: "wdn-grid-set-halves wdn-clear" 

![screen shot 2013-10-14 at 2 46 00 pm](https://f.cloud.github.com/assets/3171887/1328823/9568d15c-350a-11e3-969e-616aff0be7e0.png)
