### PR TITLE
Nav padding

### DIFF
--- a/wdn/templates_4.0/scripts/navigation.js
+++ b/wdn/templates_4.0/scripts/navigation.js
@@ -120,6 +120,8 @@ define(['jquery', 'wdn', 'modernizr', 'require'], function($, WDN, Modernizr, re
 	};
 
 	var fixPresentation = function() {
+		applyStateFixes();
+
 		var primaries = $(navPrmySel),
 			secondaryLists = $('> ul', primaries),
 			primaryLinks = $('> a', primaries),
@@ -469,7 +471,6 @@ define(['jquery', 'wdn', 'modernizr', 'require'], function($, WDN, Modernizr, re
 			}
 		};
 		Plugin.collapse(false);
-		applyStateFixes();
 
 		WDN.loadJQuery(function() {
 			require([hoverPlugin + min], function() {
@@ -589,7 +590,6 @@ define(['jquery', 'wdn', 'modernizr', 'require'], function($, WDN, Modernizr, re
 							navWidth = nav.width();
 
 							fixPresentation();
-							applyStateFixes();
 						}, resizeThrottle);
 					});
 


### PR DESCRIPTION
Problem:  When applyStateFixes() is called and outerHeight is calculated on the nav the fonts may not be loaded yet and the wrong value is calulated.

Example: http://unlcms.unl.edu/fpa

![screen shot 2013-10-16 at 11 57 14 am](https://f.cloud.github.com/assets/446357/1344661/21f5ee1e-3684-11e3-9fb7-afbdae037a2a.png)

We no longer have pinned nav available (currentState = 1 after page load)
so we don't need to set this padding in initializePreferredState. Having
it in fixPresentation makes more sense and it will be called on window
load to be sure fonts are loaded and it calcs the correct height.
