### PR TITLE
adjust notices into wdn-icon fontello namespace

### DIFF
--- a/wdn/templates_4.0/less/modules/notices.less
+++ b/wdn/templates_4.0/less/modules/notices.less
@@ -66,7 +66,7 @@
             color: darken(@light-triad, 15%);
             text-shadow: 0px 1px 0px lighten(@light-triad, 20%), 0px -1px 0px darken(@dark-triad, 10%);
             text-align: center;
-            font-family: fontello;
+            font-family: wdn-icon;
             content: "\e807";
         }
     }
@@ -107,7 +107,7 @@
         &:before {
             position: absolute;
             line-height: normal;
-            font-family: fontello;
+            font-family: wdn-icon;
         }
 
         a, a:hover {


### PR DESCRIPTION
Forgot about the notices. Should be fixed now.
