### PR TITLE
Closes #614 IE9: Set a width on .wdn-icon-menu to prevent it dropping down

### DIFF
--- a/wdn/templates_4.0/less/ie.less
+++ b/wdn/templates_4.0/less/ie.less
@@ -58,6 +58,7 @@
     .wdn-icon-menu {
         text-indent: 0\9\0;
         color: #cc0000\9\0;
+        width: 16px\9\0;
 
         &:before {
             text-indent: 0\9\0;


### PR DESCRIPTION
#614
