### PR TITLE
Fix navigation on ie11

### DIFF
--- a/wdn/templates_3.1/less/navigation/navigation.less
+++ b/wdn/templates_3.1/less/navigation/navigation.less
@@ -469,7 +469,7 @@
                 /* Secondaries */
                 
                 > ul {
-                    z-index: auto;
+                    z-index: inherit;
                     position: relative;
                     top: 0;
                     left: 0;


### PR DESCRIPTION
It was invisible, but setting the z-index to inherit, it fixes the problem.

**Issue**:
Sub navigation elements are invisible on http://snr.unl.edu/ in ie11.

**Steps to reproduce on debug.shtml**:
Copy the entire navigation from snr and replace the debug navigation.
Note: Can not reproduce in a virtual machine.  Only on an actual device with windows installed.
