### PR TITLE
Fix navigation on ie11

### DIFF
--- a/wdn/templates_3.1/less/navigation/navigation.less
+++ b/wdn/templates_3.1/less/navigation/navigation.less
@@ -469,7 +469,7 @@
                 /* Secondaries */
                 
                 > ul {
-                    z-index: inherit;
+                    z-index: 10;
                     position: relative;
                     top: 0;
                     left: 0;


### PR DESCRIPTION
Instead of using inherit, Set the z-index to the same value (10) as the parent UL.  The value `inherit` doesn't seem to always fix the problem.

https://github.com/unl/wdntemplates/pull/656
