### PR TITLE
LESSHat repo has moved to lowercase

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wdn/templates_4.0/less/_mixins/LESSHat"]
 	path = wdn/templates_4.0/less/_mixins/LESSHat
-	url = git://github.com/CSSHat/LESSHat.git
+	url = https://github.com/csshat/lesshat.git


### PR DESCRIPTION
The LESSHat repo is now at https://github.com/csshat/lesshat (all lowercase), this fixes the repo so the Travis-CI build works again.

```
$ git submodule init
Submodule 'wdn/templates_4.0/less/_mixins/LESSHat' (git://github.com/CSSHat/LESSHat.git) registered for path 'wdn/templates_4.0/less/_mixins/LESSHat'
$ git submodule update
Cloning into 'wdn/templates_4.0/less/_mixins/LESSHat'...
fatal: remote error:
Repository not found.
Clone of 'git://github.com/CSSHat/LESSHat.git' into submodule path 'wdn/templates_4.0/less/_mixins/LESSHat' failed
```
