### PR TITLE
Add display: inline to .wdn-search-icon

### DIFF
--- a/wdn/templates_4.0/less/layouts/search.less
+++ b/wdn/templates_4.0/less/layouts/search.less
@@ -5,6 +5,7 @@
         position: absolute;
         text-align: left;
         font-size: 1em;
+        display: inline;
         
         &:before {
             text-indent: 999em;


### PR DESCRIPTION
Serves as a reset if a vendor system (such as Drupal) includes a display value for the label tag.
