### PR TITLE
Add style override for empty secondary navigation

### DIFF
--- a/wdn/templates_4.0/less/states/navigation.less
+++ b/wdn/templates_4.0/less/states/navigation.less
@@ -43,6 +43,10 @@
             height: auto;
             margin-bottom: 5px;
         }
+        
+        .empty-secondary #navigation li ul {
+        	margin-bottom: 0;
+        }
     }
     
     .js { // fouc-fixes


### PR DESCRIPTION
Removes the bottom margin so there isn't any extra space below the
primaries.
