### PR TITLE
Added .wdn-inner-padding-no-top

### DIFF
--- a/wdn/templates_4.0/less/layouts/bands.less
+++ b/wdn/templates_4.0/less/layouts/bands.less
@@ -49,6 +49,10 @@
                 }
             }
 
+            &.wdn-inner-padding-no-top {
+                padding-top: 0;
+            }
+
             &.wdn-inner-padding-none {
                 padding-top: 0;
                 padding-bottom: 0;


### PR DESCRIPTION
This class could be especially useful for removing excessive amounts of white space between a page title in its own band and a block of text in another band. 
