### PR TITLE
Remove the redundent link titles from the logo links

### DIFF
--- a/wdn/templates_4.0/includes/logos.html
+++ b/wdn/templates_4.0/includes/logos.html
@@ -1,7 +1,7 @@
 <div id="wdn_logos">
     <div class="wdn-float-center">
-        <a href="http://www.unl.edu/" title="UNL Home" id="unl_wordmark">UNL Home</a>
-        <a href="http://www.cic.net/home" title="CIC Website" id="cic_wordmark">CIC Website</a>
-        <a href="http://www.bigten.org/" title="Big Ten Website" id="b1g_wordmark">Big Ten Website</a>
+        <a href="http://www.unl.edu/" id="unl_wordmark">UNL Home</a>
+        <a href="http://www.cic.net/home" id="cic_wordmark">CIC Website</a>
+        <a href="http://www.bigten.org/" id="b1g_wordmark">Big Ten Website</a>
     </div>
 </div>


### PR DESCRIPTION
As _warned_ from the WAVE tool.
