### PR TITLE
Prefix the search input id with wdn

### DIFF
--- a/wdn/templates_4.0/includes/wdnTools.html
+++ b/wdn/templates_4.0/includes/wdnTools.html
@@ -3,8 +3,8 @@
 </div>
 <div id="wdn_search" class="wdn-resource-label">
     <form id="wdn_search_form" action="http://www1.unl.edu/search/" method="get" role="search">
-        <label class="wdn-icon-search" for="q">Search</label>
-        <input accesskey="f" id="q" name="q" type="search" placeholder="Find people, pages and things" />
+        <label class="wdn-icon-search" for="wdn_search_query">Search</label>
+        <input accesskey="f" id="wdn_search_query" name="q" type="search" placeholder="Find people, pages and things" />
         <input class="search wdn-icon-search" type="submit" value="Go" />
     </form>
 </div>

--- a/wdn/templates_4.0/less/layouts/search.less
+++ b/wdn/templates_4.0/less/layouts/search.less
@@ -50,7 +50,7 @@
     }
 }
 
-#q {
+#wdn_search_query {
     width: 5px;
     border: 1px solid #d1ceb3;
     padding: 5px 5px 5px 22px;

--- a/wdn/templates_4.0/scripts/search.js
+++ b/wdn/templates_4.0/scripts/search.js
@@ -11,7 +11,7 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 	return {
 		initialize : function() {
 			$(function() {
-				var domQ = $('#q'),
+				var domQ = $('#wdn_search_query'),
 					domSearchForm = $('#wdn_search_form'),
 					siteHomepage = nav.getSiteHomepage();
 				


### PR DESCRIPTION
This helps to prevent possible conflicts, and follows the framework css standards: https://github.com/unl/wdntemplates/wiki
