### PR TITLE
Events Plugin: config passed to initializePlugin should override defaults

### DIFF
--- a/wdn/templates_4.0/scripts/events.js
+++ b/wdn/templates_4.0/scripts/events.js
@@ -56,7 +56,7 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 			container: container,
 			limit: localSettings.limit || 10
 		},
-		localConfig = $.extend({}, config, defaultConfig);
+		localConfig = $.extend({}, defaultConfig, config);
 		
 		if (localConfig.url && $(localConfig.container).length) {
 			$(this.container).addClass('wdn-calendar');


### PR DESCRIPTION
Correct the merge order of configuration objects so that options passed to the `initializePlugin` method are respected.

For a demo, look at the events plugin sample page and note that the limit parameter isn't respected.

http://wdn.unl.edu/wdn/templates_4.0/examples/#events.html
