### PR TITLE
Remove invalid `value` attribute from the share label

### DIFF
--- a/wdn/templates_4.0/includes/apps.html
+++ b/wdn/templates_4.0/includes/apps.html
@@ -22,7 +22,7 @@
 </div>
 <div class="wdn-share-this-page">
     <input type="checkbox" id="wdn_share_toggle" value="Show share options" class="wdn-input-driver" />
-    <label for="wdn_share_toggle" value="show share menu" class="wdn-icon-share">Share This Page</label>
+    <label for="wdn_share_toggle" class="wdn-icon-share">Share This Page</label>
     <ul class="wdn-share-options">
         <li><a href="http://go.unl.edu/?url=referer" id="wdn_createGoURL" class="wdn-icon-link" rel="nofollow">Get a Go URL</a></li>
         <li class="outpost" id="wdn_emailthis"><a href="mailto:" class="wdn-icon-mail" rel="nofollow">Email this page</a></li>


### PR DESCRIPTION
This fixes an HTML validation error introduced with the new share options.

```
From Jeff O'Brien:

Just received three of my sub-site checker results:

Husker Horn Studio | University of Nebraska–Lincoln
Music Education | University of Nebraska–Lincoln
Organ Studies | University of Nebraska–Lincoln

It looks like the share button that was added to the header late last week in the 4.0 template has a value tag that is being flagged by the checker. Since all of my pages are in 4.0, all of them have this error.
```

![screen shot 2014-02-17 at 8 05 35 am](https://f.cloud.github.com/assets/498678/2186140/335be780-97e1-11e3-87fa-573dbf6a2320.png)
