### PR TITLE
Improve contrast for #wdn_menu_toggle and #wdn-icon-search

### DIFF
--- a/wdn/templates_4.0/less/layouts/idm.less
+++ b/wdn/templates_4.0/less/layouts/idm.less
@@ -10,7 +10,7 @@
         text-align: right;
 
         a {
-            color: #e7b5b5;
+            color: #fae8e8;
         }
     }
 }

--- a/wdn/templates_4.0/less/layouts/navigation.less
+++ b/wdn/templates_4.0/less/layouts/navigation.less
@@ -38,7 +38,7 @@
     cursor: pointer;
     font-size: 21px;
     font-size: 1.333rem;
-    color: #e7b5b5;
+    color: #fae8e8;
     padding: 0.451em 0;
 
     &:before { // Show the navigation icon


### PR DESCRIPTION
Inexplicably, the same pink-on-red used by the nav icons was not flagged for the My.UNL Login. I’ve updated it as well.

This fixes #699 and #700.
