### PR TITLE
Improve contrast for mobile search

### DIFF
--- a/wdn/templates_4.0/less/layouts/search.less
+++ b/wdn/templates_4.0/less/layouts/search.less
@@ -27,6 +27,11 @@
         @media @bp-nav-hidden {
             color: @heading-text;
             margin-left: 7px;
+            color: #fff;
+
+            &:before {
+                color: #444341;
+            }            
         }
 
         @media @bp-nav-full {
@@ -79,7 +84,7 @@
 
         width: 100%;
         .box-sizing(border-box);
-        border: 1px solid lighten(#444340, 25%);
+        border: 1px solid #bcbab3;
         border-left-width: 28px;
         border-radius: 4px;
         padding: 6px 10px;
@@ -88,25 +93,25 @@
         .rem(13);
 
         &::-webkit-input-placeholder {
-            color: #b4b2ac;
+            color: #bcbab3;
         }
 
         &:-moz-placeholder {
-            color: #b4b2ac;
+            color: #bcbab3;
         }
 
         &::-moz-placeholder {
-            color: #b4b2ac;
+            color: #bcbab3;
         }
 
         &:-ms-input-placeholder {  
-            color: #b4b2ac;
+            color: #bcbab3;
         }
 
         &:focus {
             outline: none;
-            border-color: #b4b2ac;
-            color: #fff;
+            border-color: #e4e1d9;
+            color: #e4e1d9;
         }
     }
 


### PR DESCRIPTION
WCAG2AA
Discovered with [HTML_CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/)

I changed the label color to #fff as recommended, but changed the :before icon back to its original color. According to snook.ca [Colour Contrast Check](http://snook.ca/technical/colour_contrast/colour.html), the mobile search form was already of sufficient contrast.

Nonetheless, I did also slightly increase the contrast of the search input border and placeholder text for mobile.
