### PR TITLE
Add margin-bottom to classes .frame, .wdn-frame

### DIFF
--- a/wdn/templates_4.0/less/modules/images.less
+++ b/wdn/templates_4.0/less/modules/images.less
@@ -1,4 +1,5 @@
 .frame, .wdn-frame {
+    margin-bottom: 1em;
     border: 3px solid @faded-neutral;
 
     img {


### PR DESCRIPTION
When images are immediately followed by text in narrower browser widths (e.g. mobile), the text sits right underneath the image. This corrects that and adds an appropriate amount of whitespace between the two.
