### PR TITLE
Increased line-height for .wdn-alt-header

### DIFF
--- a/wdn/templates_4.0/less/base/text.less
+++ b/wdn/templates_4.0/less/base/text.less
@@ -29,10 +29,15 @@ p, span, div, ul, li, section, img {
 }
 
 // All caps, Gotham header
-.wdn-alt-header {
+
+.wdn-alt-header, .wdn-subhead {
     .sans-serif-font;
-    .rem(13,16);
+    line-height: 1.333;
     text-transform: uppercase;
+}
+
+.wdn-alt-header {
+    .rem(13,16);
 }
 
 // SUBHEADS
@@ -40,9 +45,6 @@ p, span, div, ul, li, section, img {
 .wdn-subhead {
     display: block;
     margin: 0.75em 0;       
-    .sans-serif-font;
-    text-transform: uppercase;
-    line-height: 1.333;
     color: fadeout(@base-text, 20%);
 }
 


### PR DESCRIPTION
The line-height for .wdn-alt-header was set to 1; I increased it to 1.333. 

Additionally, .wdn-alt-header and .wdn-subhead share some styles which I've grouped together.
