### PR TITLE
Added more specificity to borders for links within lists

### DIFF
--- a/wdn/templates_4.0/less/base/base.less
+++ b/wdn/templates_4.0/less/base/base.less
@@ -39,7 +39,7 @@ a {
     text-decoration: none;
     .transition(color 0.3s);
 
-    .wdn-main p &, .wdn-main li & {
+    .wdn-main p &, .wdn-main li > & {
         border-bottom-style: dotted;
         border-bottom-width: 1px;
 


### PR DESCRIPTION
An example that this will address is a `wdn-button` within a carousel. Currently, because the anchor is within a `<div>` within a `<li>`, it inherits the `border-bottom`. This removes it.
