### PR TITLE
Improve contrast between unvisited and visited (+hover) text links

### DIFF
--- a/wdn/templates_4.0/less/base/base.less
+++ b/wdn/templates_4.0/less/base/base.less
@@ -49,6 +49,6 @@ a {
     }
 
     &:hover, &:visited {
-        color: darken(@brand, 10%);
+        color: darken(@brand, 20%);
     }
 }


### PR DESCRIPTION
We received some feedback that visited text links were hard to distinguish from unvisited links—especially on the UNLwebaudit tool.
