### PR TITLE
Remove negative letter-spacing on #wdn_site_title

### DIFF
--- a/wdn/templates_4.0/less/layouts/header.less
+++ b/wdn/templates_4.0/less/layouts/header.less
@@ -151,7 +151,6 @@
     color: @base-text;
     .rem(23);
     line-height: 1;
-    letter-spacing: -0.02rem;
     .ligatures();
 
     a {


### PR DESCRIPTION
The negative letter-spacing, combined with the kerning and ligatures, seems to be causing some site titles to drop to two lines. The kerning and ligatures are meant to improve the spacing, so I don't know if the additional letter-spacing is all that necessary.
