### PR TITLE
Video display as block in promo bands

### DIFF
--- a/wdn/templates_4.0/less/modules/promo-image.less
+++ b/wdn/templates_4.0/less/modules/promo-image.less
@@ -1,7 +1,7 @@
 .wdn-promo-band {
 	position: relative;
 
-	img {
+	img, video {
 		display: block;
 	}
 }


### PR DESCRIPTION
Added `video` to elements that `display: block` in `.wdn-promo-band`. Without it, there's unwanted padding on the bottom of the promo band. 
