### PR TITLE
Links in .wdn_tabs_content fail contrast requirements

### DIFF
--- a/wdn/templates_4.0/examples/tabs.html
+++ b/wdn/templates_4.0/examples/tabs.html
@@ -16,6 +16,7 @@
 	<div id="tab1">
 		<h4>Tab 1</h4>
 		<p>Content for Tab 1</p>
+        <p>And here is a <a href="http://wdn.unl.edu/">link</a></p>
 	</div>
 	<div id="tab2">
 		<h4>Tab 2</h4>


### PR DESCRIPTION
There are a few options here:

1) change link colors
2) change background color of .wdn_tabs_content
3) change link color on ..wdn_tabs_content

@skoolbus39 what do you think we should do?

See http://directory.unl.edu/departments/362 as an example.
