### PR TITLE
Remove @mobile-pad at @bp-nav-max instead of @bp3

### DIFF
--- a/wdn/templates_4.0/less/layouts/bands.less
+++ b/wdn/templates_4.0/less/layouts/bands.less
@@ -53,6 +53,10 @@
                 padding-top: 0;
             }
 
+            &.wdn-inner-padding-no-bottom {
+                padding-bottom: 0;
+            }
+
             &.wdn-inner-padding-none {
                 padding-top: 0;
                 padding-bottom: 0;


### PR DESCRIPTION
At widths 960px–1020px  there's a little bit of less-than-desirable shifting going on, but it's preferable to content currently running right up against the browser chrome. Unfortunately, this shifting is really just a symptom of the design of the header, sticking the menu (hamburger) and share icons on either side of the navigation.
