### PR TITLE
Site title abbreviation contrast conformance

### DIFF
--- a/wdn/templates_4.0/less/layouts/header.less
+++ b/wdn/templates_4.0/less/layouts/header.less
@@ -196,14 +196,11 @@
         abbr[title] {
             font-size: 0;
             display: block;
-            color: fadeout(#ffffff, 100%);
 
             &:before {
                 content: attr(title);
                 .rem(30);
                 display: block;
-                color: @base-text;
-                text-shadow: 0 1px 0 #fff;
             }
         }
     }


### PR DESCRIPTION
Site title `abbr` was failing contrast conformance. I removed some unnecessary color styles to correct this. 
