### PR TITLE
Cleanup Analytics Module

### DIFF
--- a/wdn/templates_4.0/scripts/analytics.js
+++ b/wdn/templates_4.0/scripts/analytics.js
@@ -1,13 +1,7 @@
 /* global define: false */
 define(['wdn', 'idm', 'jquery'], function(WDN, idm, $) {
 	"use strict";
-	var _gaq = window._gaq,
-		_gat = window._gat,
-		ga = function() {
-			window.ga.apply(this, arguments)
-		},
-
-		wdnProp = 'UA-3203435-1',
+	var wdnProp = 'UA-3203435-1',
 		unlDomain = '.unl.edu',
 
 		defaultExt = '7z|aac|arc|arj|asf|asx|avi|bin|csv|docx?|exe|flv|gif|gz(?:ip)?|hqx|jar|jpe?g|js|m4v|mp(?:2|3|4|e?g)|mov(?:ie)?|msi|msp|pdf|phps|png|pptx?|qtm?|ra[mr]?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xlsx?|xml|z|zip',
@@ -160,7 +154,7 @@ define(['wdn', 'idm', 'jquery'], function(WDN, idm, $) {
 			}
 		},
 
-		callTrackEvent: function(category, action, label, value, noninteraction) {
+		callTrackEvent: function(category, evtaction, label, value, noninteraction) {
 			var action = 'event', method = 'send', legacyMethod = '_trackEvent', evtOpt;
 
 			if (noninteraction !== true) {
@@ -169,7 +163,7 @@ define(['wdn', 'idm', 'jquery'], function(WDN, idm, $) {
 
 			evtOpt = {
 				eventCategory: category,
-				eventAction: action,
+				eventAction: evtaction,
 				eventLabel: label,
 				eventValue: value,
 				nonInteraction: noninteraction
@@ -185,7 +179,7 @@ define(['wdn', 'idm', 'jquery'], function(WDN, idm, $) {
 							legacyValue = Math.floor(value);
 						}
 
-						tracker[legacyMethod](category, action, label, legacyValue, noninteraction);
+						tracker[legacyMethod](category, evtaction, label, legacyValue, noninteraction);
 					}
 				});
 

--- a/wdn/templates_4.0/scripts/main.js
+++ b/wdn/templates_4.0/scripts/main.js
@@ -21,13 +21,11 @@ define('modernizr', [], function () { return window.Modernizr; });
 define(['wdn', 'require', 'legacy',
         // these are the WDN plugins that are required
         'analytics',
-        'analytics_scroll_depth',
         'navigation',
         'search',
         'unlalert',
         'images'], function(WDN, require) {
 	WDN.initializePlugin('analytics');
-	WDN.initializePlugin('analytics_scroll_depth');
 	WDN.initializePlugin('navigation');
 	WDN.initializePlugin('search');
 	WDN.initializePlugin('socialmediashare');


### PR DESCRIPTION
Update the automatic link tracking for the analytics module to match what the UNLcms currently provides.

This will allow developers to control when/which links are automatically tracked using the `WDN.setPluginParam` method. Examples:
To change the file extensions tracked - `WDN.setPluginParam('analytics', 'extensions', 'pdf|zip');`
To disable file download tracking - `WDN.setPluginParam('analytics', 'trackDownload', false);`
To disable mailto link tracking - `WDN.setPluginParam('analytics', 'trackMailto', false);`
To disable outbound link tracking - `WDN.setPluginParam('analytics', 'trackOutbound', false);`

Also disable the scroll depth plugin by default, allowing developers to manually enable it on pages they'd like those events to be tracked. (start discussion here)