### PR TITLE
Add required attribute to search input

### DIFF
--- a/wdn/templates_4.0/includes/wdnTools.html
+++ b/wdn/templates_4.0/includes/wdnTools.html
@@ -1,7 +1,7 @@
 <div id="wdn_search" class="wdn-resource-label">
     <form id="wdn_search_form" action="//www1.unl.edu/search/" method="get" role="search">
 		<label class="wdn-icon-search" for="wdn_search_query">Search</label>
-        <input accesskey="f" id="wdn_search_query" name="q" type="search" />
+        <input required accesskey="f" id="wdn_search_query" name="q" type="search" />
         <button type="submit" title="Search"></button>
     </form>
 </div>


### PR DESCRIPTION
If a user presses enter without entering text in the search field, no meaningful user feedback is given. As suggested in [this article](http://css-tricks.com/users-leave-search-box-empty/) more can be done, but I thought adding the required field would be a good, quick step in the right direction.
