### PR TITLE
Share toggle positioning adjustments

### DIFF
--- a/wdn/templates_4.0/less/layouts/share.less
+++ b/wdn/templates_4.0/less/layouts/share.less
@@ -14,7 +14,7 @@
     }
 
     @media @bp2 {
-    	bottom: -70px;
+    	bottom: -69px;
     }
 
     @media @bp4 {
@@ -41,7 +41,7 @@
     }
 
     @media @bp-nav-full {
-    	padding: 8px 0 11px 10px;
+    	padding: 8px 0 10px 10px;
     }
 }
 


### PR DESCRIPTION
When navigation has no secondary elements (i.e. limited to primary elements in the red bar), the red background around the share toggle (needed for contrast conformance) extends beyond the red navigation bar. These positioning adjustments correct this.
