### PR TITLE
increase swipe length required to open navigation

### DIFF
--- a/wdn/templates_4.0/scripts/navigation.js
+++ b/wdn/templates_4.0/scripts/navigation.js
@@ -492,7 +492,7 @@ define(['jquery', 'wdn', 'modernizr', 'require'], function($, WDN, Modernizr, re
 					});
 
 					require([swipePlugin + min], function() {
-						$.event.special.swipe.horizontalDistanceThreshold = 75;
+						$.event.special.swipe.horizontalDistanceThreshold = 150;
 						$.event.special.swipe.verticalDistanceThreshold = 30;
 						$('body').on('swiperight', function() {
 							if (!isFullNav() && currentState === 0) {


### PR DESCRIPTION
When scrolling down a long page of information on a touch enabled mobile device, it was easy to accidentally open the side navigation.  This was frustrating and not expected.  This commit aims to address that issue by doubling the distance required to swipe for the navigation to open.  While it might not be a perfect solution, it is hopefully better than it used to be.

Maybe it would be better to remove this feature altogether?