### PR TITLE
Fix events RSS link on upcoming list.

### DIFF
--- a/wdn/templates_4.0/scripts/events.js
+++ b/wdn/templates_4.0/scripts/events.js
@@ -64,7 +64,7 @@ define(['jquery', 'wdn', 'require', 'moment'], function($, WDN, require, moment)
 		$container.append('<span class="see-all"><a href="'+config.url+'upcoming/">See all '+config.title+' events</a></span>');
 
 		var ics = '<a class="ics" href="' + config.url + 'upcoming/?format=ics">ICS</a>';
-		var rss = '<a class="rss" href="' + config.url + 'upcoming/?format=ics">RSS</a>';
+		var rss = '<a class="rss" href="' + config.url + 'upcoming/?format=rss">RSS</a>';
 		var feeds = '<div class="feeds">' + ics + rss + '</div>';
 		$container.append(feeds);
 		$container.show();


### PR DESCRIPTION
The link was not going to the correct feed. This two character change makes it have the right format.