### PR TITLE
Updated media query for Affiliate CSS

### DIFF
--- a/sharedcode/affiliate/css/affiliate.css
+++ b/sharedcode/affiliate/css/affiliate.css
@@ -7,9 +7,10 @@
 * The UNL Affiliate template is for sites that have approved exemptions by the Chancellor.
 * ---------------------------
 */
-@media (min-width: 700px) {
+@media (max-width: 699px) {
   #wdn_idm_user_options,
   .wdn-resource-login-trigger a {
+    color: #ffffff;
     background-color: #000000;
   }
 }

--- a/sharedcode/affiliate/less/affiliate.less
+++ b/sharedcode/affiliate/less/affiliate.less
@@ -21,7 +21,7 @@
 
 
 // !IDM
-@media @bp-nav-full {
+@media @bp-nav-hidden {
     #wdn_idm_user_options,
     .wdn-resource-login-trigger a {
         background-color: @colorPrimary;
@@ -32,6 +32,7 @@
 #navigation,
 .wdn-menu-trigger,
 .wdn-icon-share {
+    color: #ffffff;
     background-color: @colorPrimary;
 }
 


### PR DESCRIPTION
The defined media query was the opposite of the intended style. The affilate background color should be changed for narrower browser widths, not wider. I also added white as the color to replace the very light pink used in the WDN Framework.