### PR TITLE
Remove analytics scroll depth plugin

### DIFF
--- a/wdn/templates_4.0/scripts/main.js
+++ b/wdn/templates_4.0/scripts/main.js
@@ -21,13 +21,11 @@ define('modernizr', [], function () { return window.Modernizr; });
 define(['wdn', 'require', 'legacy',
         // these are the WDN plugins that are required
         'analytics',
-        'analytics_scroll_depth',
         'navigation',
         'search',
         'unlalert',
         'images'], function(WDN, require) {
 	WDN.initializePlugin('analytics');
-	WDN.initializePlugin('analytics_scroll_depth');
 	WDN.initializePlugin('navigation');
 	WDN.initializePlugin('search');
 	WDN.initializePlugin('socialmediashare');


### PR DESCRIPTION
This script was outputting too much data for too little ROI (users are, in fact, scrolling) so it should be turned off.