### PR TITLE
Remove box-shadow from disabled buttons

### DIFF
--- a/wdn/templates_4.0/less/modules/forms.less
+++ b/wdn/templates_4.0/less/modules/forms.less
@@ -18,7 +18,6 @@
     	cursor: not-allowed;
         background-color: mix(@color, #666, 45%);
         color: darken(#fff, 5%);
-        .box-shadow(0 2px 0px mix(@color, #666, 30%));
     }
 }
 


### PR DESCRIPTION
Normal buttons don't have it and it causes the buttons to appear
slightly bigger than their enabled counterparts.