### PR TITLE
Update Notice Module and Module CSS loading API

### DIFF
--- a/debug.shtml
+++ b/debug.shtml
@@ -94,30 +94,6 @@
             <div id="maincontent" class="wdn-main">
                 <!--THIS IS THE MAIN CONTENT AREA; WDN: see glossary item 'main content area' -->
                 <!-- InstanceBeginEditable name="maincontentarea" -->
-                <div class="wdn-band">
-                    <div class="wdn-inner-wrapper">
-                    	<a class="wdn-button" id="playme">Play Video</a>
-                    	<div style="display:none">
-                        <video class="wdn_player" src="http://mediahub.unl.edu/uploads/9c6b955c1f7a4ad858720ab64e72594c.mp4">
-      <track srclang="en" kind="subtitles" src="http://mediahub.unl.edu/media/3814/srt" />
-    </video>
-    <script>
-    require(['wdn', 'jquery'], function(WDN, $) {
-    	var player;
-    	
-    	$('#playme').click(function() {
-    		$(this).next().toggle();
-    		player.play();
-    	});
-    	
-    	WDN.initializePlugin('mediaelement_wdn', [function() {
-    		player = $('video.wdn_player').data('mediaelementplayer');
-    	}]);
-    });
-    </script>
-    	</div>
-                    </div>
-                </div>
                 <div class="wdn-band wdn-light-triad-band">
                     <div class="wdn-inner-wrapper">
                         <a href="#" class="wdn-button">This is my button</a> 
@@ -159,7 +135,7 @@
                 <div class="wdn-band wdn-band-neutral-seperator">
                     <div class="wdn-inner-wrapper">
 
-                        <h1><span class="wdn-subhead">Roof party freegan lomo</span> Dreamcatcher mumblecore sartorial bitters. Artisan bitters photo booth, American Apparel Bushwick PBR&B salvia Echo Park.</h1>
+                        <h1><span class="wdn-subhead">Roof party freegan lomo</span> Dreamcatcher mumblecore sartorial bitters. Artisan bitters photo booth, American Apparel Bushwick PBR&amp;B salvia Echo Park.</h1>
 
                         <p><a href="#">Before</a> they sold out Truffaut whatever scenester cred forage Odd Future Schlitz tote bag. Cosby sweater selvage whatever, Carles tofu meh vegan pickled Marfa. Thundercats kitsch post-ironic XOXO, +1 wolf kale chips Odd Future try-hard banjo selvage forage flexitarian ethnic.</p>
 
@@ -205,7 +181,7 @@
 
 
 
-                        <h1>Dreamcatcher mumblecore sartorial bitters. Artisan bitters photo booth, American Apparel Bushwick PBR&B salvia Echo Park. <span class="wdn-subhead">Roof party freegan lomo</span></h1>
+                        <h1>Dreamcatcher mumblecore sartorial bitters. Artisan bitters photo booth, American Apparel Bushwick PBR&amp;B salvia Echo Park. <span class="wdn-subhead">Roof party freegan lomo</span></h1>
 
                         <p>Before they sold out Truffaut whatever scenester cred forage Odd Future Schlitz tote bag. Cosby sweater selvage whatever, Carles tofu meh vegan pickled Marfa. Thundercats kitsch post-ironic XOXO, +1 wolf kale chips Odd Future try-hard banjo selvage forage flexitarian ethnic.</p>
 

--- a/wdn/templates_4.0/examples/notice.html
+++ b/wdn/templates_4.0/examples/notice.html
@@ -6,15 +6,12 @@
 </head>
 <body data-version="4.0">
     <div id="example-code">
-<script type="text/javascript">
-WDN.initializePlugin('notice');
-</script>
 <div class="wdn_notice">
     <div class="close">
         <a href="#" title="Close this notice">Close this notice</a>
     </div>
     <div class="message">
-        <h4>This is my Title!</h4>
+        <p class="title">This is my Title!</p>
         <p>This is my content. <a href="#">This is some link text</a>.</p>
     </div>
 </div>
@@ -23,7 +20,7 @@ WDN.initializePlugin('notice');
         <a href="#" title="Close this notice">Close this notice</a>
     </div>
     <div class="message">
-        <h4>Great Success!</h4>
+        <p class="title">Great Success!</p>
         <p>This is my content. <a href="#">This is some link text</a></p>
     </div>
 </div>
@@ -32,7 +29,7 @@ WDN.initializePlugin('notice');
         <a href="#" title="Close this notice">Close this notice</a>
     </div>
     <div class="message">
-        <h4>Denial Notice!</h4>
+        <p class="title">Denial Notice!</p>
         <p>This is my content. <a href="#">This is some link text</a></p>
     </div>
 </div>
@@ -41,28 +38,31 @@ WDN.initializePlugin('notice');
         <a href="#" title="Close this notice">Close this notice</a>
     </div>
     <div class="message">
-        <h4>Important Alert!</h4>
+        <p class="title">Important Alert!</p>
         <p>This is my content. <a href="#">This is some link text</a></p>
     </div>
 </div>
-<div class="wdn_notice overlay-header duration-10">
+<div class="wdn_notice" data-overlay="header" data-duration="10">
     <div class="close">
         <a href="#" title="Close this notice">Close this notice</a>
     </div>
     <div class="message">
-        <h4>I'm Floating!</h4>
-        <p>This notice has classes <em>overlay-header</em> and <em>duration-10</em> and will vanish on its own.</p>
+        <p class="title">I'm Floating!</p>
+        <p>This notice overlays the header and will vanish on its own in 10 seconds.</p>
     </div>
 </div>
-<div class="wdn_notice affirm overlay-maincontent duration-15">
+<div class="wdn_notice affirm" data-overlay="maincontent" data-duration="15">
     <div class="close">
         <a href="#" title="Close this notice">Close this notice</a>
     </div>
     <div class="message">
-        <h4>Success!</h4>
-        <p>This notice has classes <em>affirm</em>, <em>overlay-maincontent</em>, and <em>duration-15</em></p>
+        <p class="title">Success!</p>
+        <p>This notice overlays the maincontent and will vanish on its own in 15 seconds.</p>
     </div>
 </div>
+<script type="text/javascript">
+WDN.initializePlugin('notice');
+</script>
 </div>
 </body>
 </html>

--- a/wdn/templates_4.0/less/layouts/bands.less
+++ b/wdn/templates_4.0/less/layouts/bands.less
@@ -25,7 +25,7 @@
 
         @media @bp3 {
             padding-left: 0;
-            paading-right: 0;
+            padding-right: 0;
             width: 60rem;
         	margin: 0 auto;
         }

--- a/wdn/templates_4.0/less/layouts/bands.less
+++ b/wdn/templates_4.0/less/layouts/bands.less
@@ -1,7 +1,13 @@
 // implement the same content padding
 #maincontent > * {
-    padding-left: @mobile-pad;
-    padding-right: @mobile-pad;
+    margin-left: @mobile-pad;
+    margin-right: @mobile-pad;
+
+    @media @bp3 {
+    	max-width: 60rem;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
 
 .wdn-band {
@@ -9,17 +15,25 @@
     clear: both;
 
     #maincontent > *& {
-        padding: 0;
+        margin: 0;
     }
 
     .wdn-inner-wrapper {
         .clear-fix();
-        padding: 0 @mobile-pad;
+        padding-left: @mobile-pad;
+        padding-right: @mobile-pad;
 
         @media @bp3 {
-            padding: 0;
+            padding-left: 0;
+            paading-right: 0;
+            width: 60rem;
+        	margin: 0 auto;
         }
-        
+
+        .wdn-text-band& {
+        	max-width: 50rem;
+        }
+
         #maincontent & {
             padding-top: 2.369em;
             padding-bottom: 2.532em;
@@ -63,7 +77,7 @@
             }
         }
     }
-    
+
     .wdn-stretch { // Use this class for presentational elements that stretch the full-width of the band
         max-width: 100%;
         width: 100%;
@@ -71,33 +85,5 @@
 
     .wdn-center {
         text-align: center;
-    }
-}
-
-@media @bp3 {
-    #maincontent {
-
-        > * {
-            max-width: 60rem;
-            margin-left: auto;
-            margin-right: auto;
-            padding-left: 0;
-            padding-right: 0;
-        }
-    }
-
-    .wdn-band {
-
-        .wdn-inner-wrapper {
-            width: 60rem;
-            margin: 0 auto;
-        }
-    }
-
-    .wdn-text-band {
-
-        .wdn-inner-wrapper {
-            max-width: 50rem;
-        }
     }
 }

--- a/wdn/templates_4.0/less/modules/notices.less
+++ b/wdn/templates_4.0/less/modules/notices.less
@@ -2,7 +2,7 @@
 
 .colorize-notice(@color) {
     background-color: @color;
-    .transition(all ease-out 0.2s);
+    .transition(background ease-out 0.2s);
 
     &:hover {
         background-color: darken(@color, 2%);
@@ -24,10 +24,6 @@
     box-shadow: 0 1px 1px 0 fadeout(#000, 50%);
     .colorize-notice(@triad);
 
-    #maincontent > & {
-        padding: 1em 1em 0.75em;
-    }
-
     .close {
         color: #fff;
         
@@ -45,18 +41,18 @@
             padding: 0 0 0 4.209em;
         }
 
-        h4, p {
+        * {
             margin: 0;            
-            color: #fff;
+            color: inherit;
         }
 
-        h4 {
-            padding: 0;
+        h4, .title {
+        	// match .wdn-sans-caps
             .sans-serif-font;
 		    line-height: 1.333;
 		    text-transform: uppercase;
 		    letter-spacing: 0.02em;  
-    		.rem(13,16);
+    		font-size: inherit;
         }
 
         &:before {
@@ -74,10 +70,6 @@
             @media @bp2 {
                 width: 54px;                
             }
-        }
-
-        a, a:hover {
-            color: #fff;
         }
     }
 
@@ -150,19 +142,27 @@
         }
     }
 
-    &[class^="duration"] {
-        position: absolute;
-    }
-
-    &.overlay-header,
-    #maincontent > &.overlay-maincontent {
+    &.overlay {
         position: absolute;
         left: @mobile-pad;
         right: @mobile-pad;
         top: 51px;
-        margin: 0 auto;
-        max-width: 52rem;
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 50rem;
         z-index: (@nav-z-index + 2); // above nav
         text-align: left;
+        
+        @media @bp3 {
+        	left: 0;
+        	right: 0;
+        }
+        
+        // override the core max-width to be slimmer
+        #maincontent > & {
+	        margin-left: auto;
+	        margin-right: auto;
+        	max-width: 50rem;
+        }
     }
 }

--- a/wdn/templates_4.0/scripts/band_imagery.js
+++ b/wdn/templates_4.0/scripts/band_imagery.js
@@ -175,7 +175,7 @@ define(['jquery', 'wdn'], function($, WDN) {
 
 	var Plugin = {
 		initialize : function() {
-			WDN.loadCSS(WDN.getTemplateFilePath('css/modules/band_imagery.css'));
+			WDN.loadCSS(WDN.getTemplateFilePath('css/modules/band_imagery.css', true, true));
 			$('.wdn-scroll-watch').parent().css('position', 'relative');
 			imageryUpdate();
 			$(window).load(imageryUpdate).scroll(function() {

--- a/wdn/templates_4.0/scripts/carousel.js
+++ b/wdn/templates_4.0/scripts/carousel.js
@@ -6,7 +6,7 @@
 define(['wdn', 'require', 'jquery'], function(WDN, require, $) {
 	var defaultSel = '#wdn_Carousel',
 	flexCls = 'flexslider',
-	pluginPath = './plugins/flexslider/',
+	pluginPath = 'plugins/flexslider/',
 	initd = false;
 	
 	return {
@@ -28,10 +28,10 @@ define(['wdn', 'require', 'jquery'], function(WDN, require, $) {
 			};
 			
 			if (!initd) {
-				WDN.loadCSS(require.toUrl(pluginPath + 'css/flexslider.css'));
+				WDN.loadCSS(WDN.getTemplateFilePath('scripts/' + pluginPath + 'css/flexslider.css', true, true));
 				
 				WDN.loadJQuery(function(){
-					require([pluginPath + 'jquery.flexslider' + min], done);
+					require(['./' + pluginPath + 'jquery.flexslider' + min], done);
 				});
 			} else {
 				done();

--- a/wdn/templates_4.0/scripts/events-band.js
+++ b/wdn/templates_4.0/scripts/events-band.js
@@ -76,7 +76,7 @@ define(['jquery', 'wdn', 'require', 'moment'], function($, WDN, require, moment)
         localConfig = $.extend({}, defaultConfig, config);
 
         if (localConfig.url && $(localConfig.container).length) {
-            WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/events-band.css'));
+            WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/events-band.css', true, true));
             fetchEvents(localConfig);
         }
     };

--- a/wdn/templates_4.0/scripts/events.js
+++ b/wdn/templates_4.0/scripts/events.js
@@ -82,7 +82,7 @@ define(['jquery', 'wdn', 'require', 'moment'], function($, WDN, require, moment)
 
 		if (localConfig.url && $(localConfig.container).length) {
 			$(this.container).addClass('wdn-calendar');
-			WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/events.css'));
+			WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/events.css', true, true));
 			$.getJSON(localConfig.url + 'upcoming/?format=json&limit=' + encodeURIComponent(localConfig.limit), function(data) {
 					display(data, localConfig);
 				}

--- a/wdn/templates_4.0/scripts/extlatin.js
+++ b/wdn/templates_4.0/scripts/extlatin.js
@@ -20,7 +20,7 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
             $('head').append($extlatin);
         
             // Load WDN small caps styles
-            WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/extlatin.css'));
+            WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/extlatin.css', true, true));
         }
     };
 });

--- a/wdn/templates_4.0/scripts/form_validation.js
+++ b/wdn/templates_4.0/scripts/form_validation.js
@@ -1,7 +1,7 @@
 define(['wdn', 'require'], function(WDN, require) {
 	return {
 		initialize: function(callback) {
-			WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/formvalidator.css'));
+			WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/formvalidator.css', true, true));
 			WDN.loadJQuery(function() {
 				require(['plugins/validator/jquery.validator.min'], callback);
 			});

--- a/wdn/templates_4.0/scripts/jqueryui.js
+++ b/wdn/templates_4.0/scripts/jqueryui.js
@@ -1,5 +1,5 @@
 define(['wdn', 'require'], function(WDN, require) {
-	var pluginPath = './plugins/ui/';
+	var pluginPath = 'plugins/ui/';
 	
 	return {
 		initialize: function(callback) {
@@ -8,9 +8,9 @@ define(['wdn', 'require'], function(WDN, require) {
 				min = '.min';
 			}
 			
-			WDN.loadCSS(require.toUrl(pluginPath + 'css/jquery-ui' + min + '.css'));
+			WDN.loadCSS(WDN.getTemplateFilePath('scripts/' + pluginPath + 'css/jquery-ui' + min + '.css', true, true));
 			WDN.loadJQuery(function() {
-				require([pluginPath + 'jquery-ui' + min], callback);
+				require(['./' + pluginPath + 'jquery-ui' + min], callback);
 			});
 		}
 	};

--- a/wdn/templates_4.0/scripts/mediaelement_wdn.js
+++ b/wdn/templates_4.0/scripts/mediaelement_wdn.js
@@ -3,7 +3,7 @@
  *
  */
 define(['jquery', 'wdn', 'require'], function($, WDN, require) {
-	var pluginPath = './plugins/mediaelement/',
+	var pluginPath = 'plugins/mediaelement/',
 	initd = false;
 
 	return {
@@ -24,7 +24,7 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 			}
 
 			if (!initd) {
-				WDN.loadCSS(require.toUrl(pluginPath + 'css/mediaelementplayer' + min + '.css'));
+				WDN.loadCSS(WDN.getTemplateFilePath('scripts/' + pluginPath + 'css/mediaelementplayer' + min + '.css', true, true));
 				initd = true;
 			}
 
@@ -38,8 +38,8 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 				}
 			};
 
-			require([pluginPath + 'mediaelement-and-player' + min], function() {
-				require([pluginPath + 'mep-feature-googleanalytics'], ready);
+			require(['./' + pluginPath + 'mediaelement-and-player' + min], function() {
+				require(['./' + pluginPath + 'mep-feature-googleanalytics'], ready);
 			});
 		}
 	};

--- a/wdn/templates_4.0/scripts/modal.js
+++ b/wdn/templates_4.0/scripts/modal.js
@@ -1,5 +1,5 @@
 define(['wdn', 'require'], function(WDN, require) {
-	var pluginPath = './plugins/colorbox/', initd = false;
+	var pluginPath = 'plugins/colorbox/', initd = false;
 	
     return {
         initialize : function(callback) {
@@ -12,7 +12,7 @@ define(['wdn', 'require'], function(WDN, require) {
         			if (!body.length || !body[0].className.match(/(^|\s)debug(\s|$)/)) {
         				min = '-min';
         			}
-            		require([pluginPath + 'jquery.colorbox' + min], function() {
+            		require(['./' + pluginPath + 'jquery.colorbox' + min], function() {
             			WDN.jQuery.colorbox.settings.className = 'wdn-main';
             			callback();
             		});
@@ -20,7 +20,7 @@ define(['wdn', 'require'], function(WDN, require) {
             };
             
             if (!initd) {
-            	WDN.loadCSS(require.toUrl(pluginPath + 'css/colorbox.css'), ready);
+            	WDN.loadCSS(WDN.getTemplateFilePath('scripts/' + pluginPath + 'css/colorbox.css', true, true), ready);
             } else {
             	ready();
             }

--- a/wdn/templates_4.0/scripts/modernizr-wdn.js
+++ b/wdn/templates_4.0/scripts/modernizr-wdn.js
@@ -918,33 +918,33 @@ Modernizr.selectorSupported = function(selector) {
             hasFeature: function() {
                 return false;
             }
-        },
+        };
 
-        link = doc.createElement("style");
-        link.type = 'text/css';
+    link = doc.createElement("style");
+    link.type = 'text/css';
 
-        (head || root).insertBefore(link, (head || root).firstChild);
+    (head || root).insertBefore(link, (head || root).firstChild);
 
-        sheet = link.sheet || link.styleSheet;
+    sheet = link.sheet || link.styleSheet;
 
-        if (!(sheet && selector)) return false;
+    if (!(sheet && selector)) return false;
 
-        support = impl.hasFeature('CSS2', '') ?
+    support = impl.hasFeature('CSS2', '') ?
 
-            function(selector) {
-              try {
-                  sheet.insertRule(selector + '{ }', 0);
-                  sheet.deleteRule(sheet.cssRules.length - 1);
-              } catch (e) {
-                  return false;
-              }
-              return true;
+        function(selector) {
+          try {
+              sheet.insertRule(selector + '{ }', 0);
+              sheet.deleteRule(sheet.cssRules.length - 1);
+          } catch (e) {
+              return false;
+          }
+          return true;
 
-          } : function(selector) {
+      } : function(selector) {
 
-              sheet.cssText = selector + ' { }';
-              return sheet.cssText.length !== 0 && !(/unknown/i).test(sheet.cssText) && sheet.cssText.indexOf(selector) === 0;
-          };
+          sheet.cssText = selector + ' { }';
+          return sheet.cssText.length !== 0 && !(/unknown/i).test(sheet.cssText) && sheet.cssText.indexOf(selector) === 0;
+      };
 
       result = support(selector);
       link.parentNode.removeChild(link);
@@ -960,6 +960,49 @@ Modernizr.selectorSupported = function(selector) {
             return Modernizr.selectorSupported(selector);
         });
     }
+})();
+
+// custom feature detect for link element onload events
+(function() {
+	var doc = document,
+	    root = doc.documentElement,
+	    head = root.getElementsByTagName('head')[0],
+	    testName = 'linkloadevents',
+	    failTimeout,
+	    onDone,
+	    link = doc.createElement('link');
+
+	link.rel = 'stylesheet';
+    link.href = 'data:text/css;base64,I21vZGVybml6ci1jc3Nsb2Fke2Rpc3BsYXk6bm9uZX0=';
+    
+    onDone = function(result) {
+    	Modernizr.addTest(testName, result);
+    	if (link.parentNode) {
+    		link.parentNode.removeChild(link);
+    	}
+    	link = null;
+    }
+
+	if (!Modernizr.hasEvent('load', link)) {
+		onDone(false);
+		return;
+	}
+	
+	link.onload = function() {
+		clearTimeout(failTimeout);
+		onDone(!!(link.sheet || link.styleSheet));
+	};
+	
+	link.onerror = function() {
+		clearTimeout(failTimeout);
+		onDone(true);
+	};
+	
+    (head || root).insertBefore(link, (head || root).firstChild);
+    
+    failTimeout = setTimeout(function() {
+    	onDone(false);
+    }, 100);
 })();
 
 //Method of allowing calculated values for length units, i.e. width: calc(100%-3em) http://caniuse.com/#search=calc

--- a/wdn/templates_4.0/scripts/monthwidget.js
+++ b/wdn/templates_4.0/scripts/monthwidget.js
@@ -105,7 +105,7 @@ define(['jquery', 'wdn', 'require', 'moment'], function($, WDN, require, moment)
 		localConfig = $.extend({}, config, defaultConfig);
 
 		if (localConfig.url && $(localConfig.container).length) {
-			WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/monthwidget.css'));
+			WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/monthwidget.css', true, true));
 			$.get(localConfig.url + '?monthwidget&format=hcalendar', function(data) {
 					display(data, localConfig);
 				}

--- a/wdn/templates_4.0/scripts/notice.js
+++ b/wdn/templates_4.0/scripts/notice.js
@@ -16,7 +16,7 @@ define(['jquery', 'wdn'], function($, WDN) {
 		initialize : function() {
 			// prevent double initialiation
 			if (!initd) {
-				WDN.loadCSS(WDN.getTemplateFilePath(templateCssFile));
+				WDN.loadCSS(WDN.getTemplateFilePath(templateCssFile, true, true));
 				
 				// globally listen for notice close button clicks
 				$(document).on('click', selectorNamespace + ' .close', function() {

--- a/wdn/templates_4.0/scripts/rss_widget.js
+++ b/wdn/templates_4.0/scripts/rss_widget.js
@@ -33,7 +33,7 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 		    }
 		    
 		    if (!initd) {
-		    	WDN.loadCSS(WDN.getTemplateFilePath('css/modules/rsswidget.css'));
+		    	WDN.loadCSS(WDN.getTemplateFilePath('css/modules/rsswidget.css', true, true));
 		    	WDN.loadJQuery(function() {
 		    		require(['plugins/rsswidget/jquery.zrssfeed.min'], function() {
 		    			initd = true;

--- a/wdn/templates_4.0/scripts/smallcaps.js
+++ b/wdn/templates_4.0/scripts/smallcaps.js
@@ -20,7 +20,7 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
             $('head').append($smcaps);
         
             // Load WDN small caps styles
-            WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/smallcaps.css'));
+            WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/smallcaps.css', true, true));
         }
     };
 });

--- a/wdn/templates_4.0/scripts/tooltip.js
+++ b/wdn/templates_4.0/scripts/tooltip.js
@@ -76,7 +76,7 @@ define(['jquery', 'require'], function($, require) {
 			}
 
 			if (!initd) {
-				WDN.loadCSS(require.toUrl(pluginPath + wdnStyle + min + '.css'));
+				WDN.loadCSS(WDN.getTemplateFilePath('scripts/' + pluginPath + wdnStyle + min + '.css', true, true));
 				require([pluginPath + qtipPlugin + min], function() {
 					initd = true;
 					tooltipSetup();

--- a/wdn/templates_4.0/scripts/unlalert.js
+++ b/wdn/templates_4.0/scripts/unlalert.js
@@ -158,7 +158,7 @@ define(['jquery', 'wdn'], function($, WDN) {
 		for (i = 0; i < info.length; i++) {
 			// Add a div to store the html content
 			if (!$alertWrapper.length) {
-				WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/unlalert.css'));
+				WDN.loadCSS(WDN.getTemplateFilePath('css/layouts/unlalert.css', true, true));
 
 				$alertWrapper = $('<div>', {
 					'id': idPrfx,

--- a/wdn/templates_4.0/scripts/wdn.js
+++ b/wdn/templates_4.0/scripts/wdn.js
@@ -69,12 +69,12 @@
 		loadCSS: function (url, callback, checkLoaded, callbackIfLoaded) {
 			url = _sanitizeTemplateUrl(url);
 			
-			var e = (function() {
-					var e = document.createElement("link");
-					e.href = url;
-					e.rel = "stylesheet";
-					e.type = "text/css";
-					return e;
+			var link = (function() {
+					var link = document.createElement("link");
+					link.href = url;
+					link.rel = "stylesheet";
+					link.type = "text/css";
+					return link;
 				})(),
 				executeCallback = function() {
 					loadedCSS[url] = true;
@@ -105,7 +105,7 @@
 					dummyObj.onerror = executeCallback;
 					dummyObj.src = url;
 				} else {
-					e.onload = executeCallback;
+					link.onload = executeCallback;
 				}
 				
 				_head.appendChild(e);

--- a/wdn/templates_4.0/scripts/wdn.js
+++ b/wdn/templates_4.0/scripts/wdn.js
@@ -1,7 +1,3 @@
-/**
- * This file contains the WDN template javascript code.
- */
-
 (function(window, undefined) {
 	var 
 		pluginParams = {},
@@ -32,23 +28,28 @@
 			return url;
 		};
 		
-	
-	var req = function() {
-		//TODO: Make this work if require is gone
-		(window.require).apply(this, arguments);
-	};
-	
 	//#TEMPLATE_PATH
 	//#DEPENDENT_PATH
 	
 	var WDN = {
 		
-		getTemplateFilePath: function(file, withTemplatePath) {
+		getTemplateFilePath: function(file, withTemplatePath, withVersion) {
 			file = '' + file;
 			var filePath = dependent_path + file;
 			
 			if (withTemplatePath) {
 				filePath = template_path + filePath;
+			}
+			
+			if (withVersion) {
+				var qsPosition = filePath.indexOf('?');
+				if (qsPosition < 0) {
+					filePath += '?';
+				} else if (qsPosition !== filePath.length - 1) {
+					filePath += '&';
+				}
+				
+				filePath += 'dep=' + WDN.getDepVersion();
 			}
 			
 			return filePath;
@@ -59,7 +60,7 @@
 		 */
 		loadJS: function (url,callback) {
 			url = _sanitizeTemplateUrl(url);
-			req([url], callback);
+			window.require([url], callback);
 		},
 
 		/**
@@ -68,55 +69,48 @@
 		loadCSS: function (url, callback, checkLoaded, callbackIfLoaded) {
 			url = _sanitizeTemplateUrl(url);
 			
-			var _getLink = function() {
+			var e = (function() {
 					var e = document.createElement("link");
 					e.href = url;
 					e.rel = "stylesheet";
 					e.type = "text/css";
 					return e;
-				},
-				e = _getLink(),
-				dummyObj,
+				})(),
 				executeCallback = function() {
-					dummyObj = undefined;
-					
 					loadedCSS[url] = true;
 					if (loadingCSS[url]) {
-						for (var i = 0; i < loadingCSS[url].length; i++) {
+						for (var i = loadingCSS[url].length - 1; i >= 0; i--) {
 							loadingCSS[url][i]();
 						}
 						delete loadingCSS[url];
 					}
 				};
 			
-			if (!callback) {
-				e.onload = function() {
-					loadedCSS[url] = true;
-				};
-				_head.appendChild(e);
-				
-				return;
-			}
-			
-			// Workaround for webkit and old gecko not firing onload events for <link>
-			// http://www.backalleycoder.com/2011/03/20/link-tag-css-stylesheet-load-event/
-			
 			if (checkLoaded === false || !(url in loadedCSS)) {
-				if (url in loadingCSS) {
-					loadingCSS[url].push(callback);
-					return;
+				if (callback) { 
+					if (url in loadingCSS) {
+						loadingCSS[url].push(callback);
+						return;
+					}
+					
+					loadingCSS[url] = [callback];
+				} else if (!(url in loadingCSS)) {
+					loadingCSS[url] = [];
+				}
+			
+				if (callback && !window.Modernizr.linkloadevents) {
+					// Workaround for webkit and old gecko not firing onload events for <link>
+					// http://www.backalleycoder.com/2011/03/20/link-tag-css-stylesheet-load-event/
+					var dummyObj = document.createElement('img');
+					dummyObj.onerror = executeCallback;
+					dummyObj.src = url;
+				} else {
+					e.onload = executeCallback;
 				}
 				
-				loadingCSS[url] = [callback];
-				
-				dummyObj = document.createElement('img');
-				dummyObj.onerror = executeCallback;
-				dummyObj.src = url;
 				_head.appendChild(e);
-			} else {
-				if (callbackIfLoaded !== false) {
-					callback();
-				}
+			} else if (callbackIfLoaded !== false) {
+				callback();
 			}
 		},
 
@@ -124,9 +118,8 @@
 		 * Load jQuery included with the templates as WDN.jQuery
 		 *
 		 * @param callback Called when the document is ready
-		 * @param forceDebug Should the debug jQuery be loaded
 		 */
-		loadJQuery: function (callback, forceDebug) {
+		loadJQuery: function (callback) {
 			require(['jquery'], function($) {
 				if (typeof WDN.jQuery === "undefined") {
 					WDN.jQuery = $.noConflict(true);
@@ -202,7 +195,7 @@
 				args = [];
 			}
 			
-			req([plugin], function(pluginObj) {
+			window.require([plugin], function(pluginObj) {
 				var defaultOnLoad = onLoad = function () {
 					if (pluginObj && "initialize" in pluginObj) {
 						WDN.log("initializing plugin '" + plugin + "'");

--- a/wdn/templates_4.0/scripts/wdn.js
+++ b/wdn/templates_4.0/scripts/wdn.js
@@ -108,7 +108,7 @@
 					link.onload = executeCallback;
 				}
 				
-				_head.appendChild(e);
+				_head.appendChild(link);
 			} else if (callbackIfLoaded !== false) {
 				callback();
 			}


### PR DESCRIPTION
* Reverts bad commit to debug html instance
* Changes the example markup for notice
* Updates the core band styles to use margin to offset the page-pad on mobile
* Updates notice styles to not do so many overrides
* Cleanup WDN api to remove dead code and add a method for getting a versioned template file URL
* Update all modules to use the versioned template file URL getter for loading CSS.