### PR TITLE
Use only nickname or first name in IdM module

### DIFF
--- a/wdn/templates_4.0/scripts/idm.js
+++ b/wdn/templates_4.0/scripts/idm.js
@@ -49,15 +49,11 @@ define(['wdn', 'jquery', 'require'], function(WDN, $, require) {
 		},
 
 		userDisplayName = function() {
-			var disp_name = '', i;
-			if ((user.eduPersonNickname || user.givenName) && user.sn) {
-				if (user.eduPersonNickname) {
-					disp_name = user.eduPersonNickname[0]
-				} else {
-					disp_name = user.givenName[0];
-				}
-
-				disp_name += ' ' + user.sn[0][0] + '.';
+			var disp_name = '';
+			if (user.eduPersonNickname) {
+				disp_name = user.eduPersonNickname[0]
+			} else if (user.givenName) {
+				disp_name = user.givenName[0];
 			} else if (user.displayName) {
 				disp_name = user.displayName[0];
 			}


### PR DESCRIPTION
If these fields are available the first letter of the surname will no
longer be added. Otherwise, the full "display name" will be used.
Closes #751.