### PR TITLE
Give #maincontent focus on skipnav click

### DIFF
--- a/wdn/templates_4.0/scripts/main.js
+++ b/wdn/templates_4.0/scripts/main.js
@@ -18,13 +18,14 @@ require.config({
 //Modernizr, WDN are loaded prior to requireJS
 define('modernizr', [], function () { return window.Modernizr; });
 
-define(['wdn', 'skipnav', 'require', 'legacy',
+define(['wdn', 'require', 'legacy',
         // these are the WDN plugins that are required
         'analytics',
         'navigation',
         'search',
         'unlalert',
-        'images'], function(WDN, require) {
+        'images', 
+        'skipnav'], function(WDN, require) {
 	WDN.initializePlugin('analytics');
 	WDN.initializePlugin('navigation');
 	WDN.initializePlugin('search');

--- a/wdn/templates_4.0/scripts/main.js
+++ b/wdn/templates_4.0/scripts/main.js
@@ -18,7 +18,7 @@ require.config({
 //Modernizr, WDN are loaded prior to requireJS
 define('modernizr', [], function () { return window.Modernizr; });
 
-define(['wdn', 'require', 'legacy',
+define(['wdn', 'skipnav', 'require', 'legacy',
         // these are the WDN plugins that are required
         'analytics',
         'navigation',

--- a/wdn/templates_4.0/scripts/skipnav.js
+++ b/wdn/templates_4.0/scripts/skipnav.js
@@ -1,4 +1,6 @@
-define([], function() {
+define(['jquery'], function($) {
 	//Fix skipnav to maincontent (maincontent was not focuable, and thus the tab order would revert to the top of the page)
-	document.getElementById('maincontent').setAttribute('tabindex', '-1');
+	$(function() {
+		$('#maincontent').attr('tabindex', '-1');
+	})
 });

--- a/wdn/templates_4.0/scripts/skipnav.js
+++ b/wdn/templates_4.0/scripts/skipnav.js
@@ -1,0 +1,4 @@
+define([], function() {
+	//Fix skipnav to maincontent (maincontent was not focuable, and thus the tab order would revert to the top of the page)
+	document.getElementById('maincontent').setAttribute('tabindex', '-1');
+});


### PR DESCRIPTION
This fixes an issue where if the skipnav link was clicked, focus was not being set to the #maincontent div.  The screen would just visually focus on the area, rather than move tab focus to the maincontent area.

fixes #829 