### PR TITLE
Improve a11y for the search feature

### DIFF
--- a/wdn/templates_4.0/scripts/search.js
+++ b/wdn/templates_4.0/scripts/search.js
@@ -155,11 +155,41 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 					}
 				});
 
+				var closeSearch = function() {
+					var $wdnSearch = domSearchForm.parent();
+					$wdnSearch.removeClass('active');
+				};
+
+				//Close search on escape while the iframe has focus
+				$(window).on('message', function(e) {
+					var originalEvent = e.originalEvent;
+					
+					if ('wdn.search.close' != originalEvent.data) {
+						//Make sure this is our event
+						return;
+					}
+					
+					if (searchOrigin != originalEvent.origin) {
+						//Verify the origin
+						return;
+					}
+					
+					closeSearch();
+				});
+
+				//Close search on escape
+				$(document).on('keydown', function(e) {
+					if (!e.keyCode || e.keyCode === 27) {
+						//Close on escape
+						closeSearch();
+					}
+				});
+
 				// listen for clicks on the document and hide the iframe if they didn't come from search interface
 				$(document).on('click', function(e) {
 					var $wdnSearch = domSearchForm.parent();
 					if (!$wdnSearch.find(e.target).length) {
-						$wdnSearch.removeClass('active');
+						closeSearch();
 					}
 				});
 			});

--- a/wdn/templates_4.0/scripts/search.js
+++ b/wdn/templates_4.0/scripts/search.js
@@ -101,14 +101,14 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 					clearTimeout(autoSubmitTimeout);
 					if ($(this).val()) {
 						autoSubmitTimeout = setTimeout(function() {
-							domSearchForm.submit();
+							domSearchForm.trigger('submit', 'auto');
 						}, 300);
 					}
 				});
 
 				$progress = $('<progress>', {id: 'wdn_search_progress'}).text('Loading...');
 
-				domSearchForm.on('submit', function(e) {
+				domSearchForm.on('submit', function(e, source) {
 					// disable iframe and return if not in "desktop" presentation
 					if (!isFullNav()) {
 						this.target = '';
@@ -131,6 +131,11 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 								return;
 							}
 
+							if ('auto' != source) {
+								//a11y: send focus to the results if manually submitted
+								$unlSearch.focus();
+							}
+
 							$progress.hide();
 							postReady = true; // iframe should be ready to post messages to
 						});
@@ -151,6 +156,10 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 					if (postReady && $unlSearch[0].contentWindow.postMessage) {
 						e.preventDefault();
 						$unlSearch[0].contentWindow.postMessage(domQ.val(), searchOrigin);
+						if ('auto' != source) {
+							//a11y: send focus to the results if manually submitted
+							$unlSearch.focus();
+						}
 						$progress.hide();
 					}
 				});

--- a/wdn/templates_4.0/scripts/search.js
+++ b/wdn/templates_4.0/scripts/search.js
@@ -188,7 +188,7 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 
 				//Close search on escape
 				$(document).on('keydown', function(e) {
-					if (!e.keyCode || e.keyCode === 27) {
+					if (e.keyCode === 27) {
 						//Close on escape
 						closeSearch();
 					}

--- a/wdn/templates_4.0/scripts/search.js
+++ b/wdn/templates_4.0/scripts/search.js
@@ -131,7 +131,7 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 								return;
 							}
 
-							if ('auto' != source) {
+							if ('auto' !== source) {
 								//a11y: send focus to the results if manually submitted
 								$unlSearch.focus();
 							}


### PR DESCRIPTION
This does two things to improve a11y for the search feature.

1. fixes #885 - Pressing escape will close the results pane.  This could be further improved by adding a link to close the results pane (but I'm not sure exactly how the would look).
2. Send focus to the results pane on manual submit (not autocomplete)

Note that an update to the search application will have to be rolled out at the same time.  There is a paired PR for that project which I will submit in just a second.