### PR TITLE
Fix bug in firefox where search was not being closed

### DIFF
--- a/wdn/templates_4.0/scripts/search.js
+++ b/wdn/templates_4.0/scripts/search.js
@@ -97,6 +97,12 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 					if (!isFullNav()) {
 						return;
 					}
+					
+					if (e0.keyCode === 27) {
+						//Close on escape
+						closeSearch();
+						return;
+					}
 
 					clearTimeout(autoSubmitTimeout);
 					if ($(this).val()) {
@@ -167,6 +173,7 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 				var closeSearch = function() {
 					var $wdnSearch = domSearchForm.parent();
 					$wdnSearch.removeClass('active');
+					domQ.val('');
 				};
 
 				//Close search on escape while the iframe has focus


### PR DESCRIPTION
In firefox, the form was being submitted before being closed, and thus re-opened right away, appearing as a flash.