### PR TITLE
Prevent validation styles from showing on search close

### DIFF
--- a/wdn/templates_4.0/scripts/search.js
+++ b/wdn/templates_4.0/scripts/search.js
@@ -173,7 +173,7 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 				var closeSearch = function() {
 					var $wdnSearch = domSearchForm.parent();
 					$wdnSearch.removeClass('active');
-					domQ.val('');
+					domSearchForm[0].reset();
 				};
 
 				//Close search on escape while the iframe has focus


### PR DESCRIPTION
Setting the input value to '' causes FireFox to mark the input as invalid because it is required.  To prevent this, simply reset the form instead.