### PR TITLE
Revert to previous dropdown styles

### DIFF
--- a/wdn/templates_4.1/less/states/search.less
+++ b/wdn/templates_4.1/less/states/search.less
@@ -3,11 +3,6 @@
 #wdn_search {
 
     @media @bp-nav-hidden {
-
-        #wdn_search_form {
-            display: none;
-        }
-        
         .nav-scrolling & {
             position: fixed;
             z-index: (@nav-z-index + 1);
@@ -21,7 +16,6 @@
 
         .wdn_search_toggle:checked ~ #wdn_search_form {
             .is-visible();
-            display: block;
             transform: scale(1);
             transition: opacity 0.1s ease-in-out, transform 0.1s ease-in-out;
         }


### PR DESCRIPTION
Using display:block and display:none removes the existing transitions for the dropdowns.