### PR TITLE
Add a missing bracket

### DIFF
--- a/wdn/templates_4.1/scripts/wdn-ui.js
+++ b/wdn/templates_4.1/scripts/wdn-ui.js
@@ -70,7 +70,7 @@ define(['jquery'], function($) {
 				$container.attr('aria-hidden', true);
 				
 				//Add a helper class to labels
-				var $label = $('label[for="'+$element.attr('id')+'"');
+				var $label = $('label[for="'+$element.attr('id')+'"]');
 				$label.addClass('wdn-dropdown-widget-label');
 			});
 			


### PR DESCRIPTION
This was causing JS to fail in some browsers

This should be released ASAP as it is actively breaking pages.