### PR TITLE
Enforce a11y for headings in footer

### DIFF
--- a/sharedcode/affiliate/localFooter.html
+++ b/sharedcode/affiliate/localFooter.html
@@ -1,7 +1,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp640-wdn-col-two-thirds bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">Buros Center for Testing<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading">Buros Center for Testing<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp960-wdn-grid-set-halves">
 				<div class="wdn-col">
 					<p class="wdn-icon-location">21 Teachers College Hall<br />

--- a/sharedcode/localFooter.html
+++ b/sharedcode/localFooter.html
@@ -2,7 +2,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp640-wdn-col-two-thirds bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp960-wdn-grid-set-halves">
 				<div class="wdn-col">
 					<p class="wdn-icon-location">102 Woods Art Building<br />
@@ -24,7 +24,7 @@
 	</div>
 	<div class="wdn-col-full bp640-wdn-col-one-third bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">Related Links</span>
+			<span role="heading">Related Links</span>
 			<ul class="wdn-related-links-v1">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>
@@ -41,7 +41,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp640-wdn-col-two-thirds bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp960-wdn-grid-set-halves">
 				<div class="wdn-col">
 					<p class="wdn-icon-location">102 Woods Art Building<br />
@@ -63,7 +63,7 @@
 	</div>
 	<div class="wdn-col-full bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">Related Links</span>
+			<span role="heading">Related Links</span>
 			<ul class="wdn-related-links-v2">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>
@@ -91,7 +91,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp960-wdn-col-three-fourths">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">College of Engineering<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading">College of Engineering<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp640-wdn-grid-set-thirds bp960-wdn-grid-set-thirds">
 				<div class="wdn-col">
 					<p class="wdn-icon-location">114 Othmer Hall/820 N 16th St.<br />
@@ -122,7 +122,7 @@
 	</div>
 	<div class="wdn-col-full bp960-wdn-col-one-fourth">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">Related Links</span>
+			<span role="heading">Related Links</span>
 			<ul class="wdn-related-links-v3">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>
@@ -144,7 +144,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">University of Nebraska&ndash;Lincoln<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading">University of Nebraska&ndash;Lincoln<span class="wdn-text-hidden"> Contact Information</span></span>
 			<p class="wdn-icon-location">1400 'R' Street<br />
 			Lincoln, NE 68588</p>
 			<p class="wdn-icon-phone"><a href="tel:4024727211">402-472-7211</a></p>
@@ -152,7 +152,7 @@
 	</div>
 	<div class="wdn-col-full bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading" class="wdn-footer-heading">Related Links</span>
+			<span role="heading">Related Links</span>
 			<ul class="wdn-related-links-v4">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>

--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -1,7 +1,7 @@
 <div class="wdn-grid-set bp480-wdn-grid-set-thirds bp960-wdn-grid-set-fourths">
 	<div class="wdn-col">
 		<div class="wdn-footer-module wdn-footer-social">
-			<span role="heading" class="wdn-footer-heading">Connect with #UNL</span>
+			<span role="heading">Connect with #UNL</span>
 			<ul class="wdn-footer-list">
 				<li><a href="http://www.facebook.com/UNLincoln" class="wdn-footer-list-item wdn-icon-facebook">UNLincoln <span class="wdn-text-hidden"> on Facebook</span></a></li>
 				<li><a href="http://www.twitter.com/UNLincoln" class="wdn-footer-list-item wdn-icon-twitter">@UNLincoln<span class="wdn-text-hidden"> on Twitter</span></a></li>
@@ -15,7 +15,7 @@
 	</div>
 	<div class="wdn-col">
 		<div class="wdn-footer-module wdn-footer-campus">
-			<span role="heading" class="wdn-footer-heading">Campus <span class="wdn-text-hidden">Links</span></span>
+			<span role="heading">Campus <span class="wdn-text-hidden">Links</span></span>
 			<ul class="wdn-footer-list">
 				<li><a href="http://directory.unl.edu/" class="wdn-footer-list-item">Directory</a></li>
 				<li><a href="https://employment.unl.edu/" class="wdn-footer-list-item">Employment</a></li>
@@ -29,7 +29,7 @@
 	</div>
 	<div class="wdn-col">
 		<div class="wdn-footer-module wdn-footer-policies">
-			<span role="heading" class="wdn-footer-heading">Policies</span>
+			<span role="heading">Policies</span>
 			<ul class="wdn-footer-list">
 				<li><a href="http://emergency.unl.edu/" class="wdn-footer-list-item">Emergency Planning and Preparedness</a></li>
 				<li><a href="http://www.unl.edu/equity/" class="wdn-footer-list-item">Institutional Equity and Compliance</a></li>

--- a/wdn/templates_4.1/less/layouts/footer.less
+++ b/wdn/templates_4.1/less/layouts/footer.less
@@ -50,15 +50,15 @@
             color: @ui07;
         }
     }
-}
-
-.wdn-footer-heading {
-	display: block;
-    margin: 0 0 0.75em 0;
-    .brand-font();
-    .rem(21,23);
-    text-transform: uppercase;
-    line-height: 1.069;
+	
+	span[role="heading"] {
+		display: block;
+		margin: 0 0 0.75em 0;
+		.brand-font();
+		.rem(21,23);
+		text-transform: uppercase;
+		line-height: 1.069;
+	}
 }
 
 .wdn-footer-module {
@@ -102,7 +102,7 @@
 		}
 	}
 
-	.wdn-footer-heading {
+	span[role="heading"] {
 		color: @ui04;
 	}
 }
@@ -199,7 +199,7 @@
 		}
 	}
 
-	.wdn-footer-heading {
+	span[role="heading"] {
 		color: @ui05;
 	}
 


### PR DESCRIPTION
Don't rely on the `wdn-footer-heading` cass, which would still work if the `role="heading"` attribute was missing. By writing the css to require the `role="heading"`, people will be less likely to forget that attribute.

I found this while updating some applications to use 4.1. I hope it isn't too late to make this change.