### PR TITLE
Breadcrumb, navigation, color updates

### DIFF
--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -20,8 +20,8 @@
 				<li><a href="http://directory.unl.edu/" class="wdn-footer-list-item">Directory</a></li>
 				<li><a href="https://employment.unl.edu/" class="wdn-footer-list-item">Employment</a></li>
 				<li><a href="http://events.unl.edu/" class="wdn-footer-list-item">Events</a></li>
+				<li><a href="http://libraries.unl.edu/" class="wdn-footer-list-item">Libraries</a></li>
 				<li><a href="http://maps.unl.edu/" class="wdn-footer-list-item">Maps</a></li>
-				<li><a href="http://marketplace.unl.edu/" class="wdn-footer-list-item">Marketplace</a></li>
 				<li><a href="http://www.unl.edu/chancellor/" class="wdn-footer-list-item">Office of the Chancellor</a></li>
 				<li><a href="http://news.unl.edu/newsrooms/unltoday/" class="wdn-footer-list-item">UNL Today</a></li>
 			</ul>

--- a/wdn/templates_4.1/less/_mixins/colors.less
+++ b/wdn/templates_4.1/less/_mixins/colors.less
@@ -1,7 +1,7 @@
 // GO B1G RED
 
 	// Scarlet
-	@scarlet: #d00000;
+	@scarlet: #dd0000;
 	@brand: @scarlet;
 
 	// Cream
@@ -54,7 +54,7 @@
 
 // Assign base colors
 
-    // Base text and heading text colors    
+    // Base text and heading text colors
     @heading-text: @ui09;
     @base-text: @ui08;
 

--- a/wdn/templates_4.1/less/layouts/breadcrumbs.less
+++ b/wdn/templates_4.1/less/layouts/breadcrumbs.less
@@ -111,17 +111,20 @@
 
 		&:last-child {
 
-			@media @bp-nav-full {
-			    padding-left: 23px;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                background: transparent;
-			}
+            &:not(.last-link) {
 
-			&:after {
-				display: none;
-			}
+    			@media @bp-nav-full {
+    			    padding-left: 23px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                    background: transparent;
+    			}
+
+    			&:after {
+    				display: none;
+    			}
+            }
 		}
 
 		&.selected {

--- a/wdn/templates_4.1/less/layouts/navigation.less
+++ b/wdn/templates_4.1/less/layouts/navigation.less
@@ -151,6 +151,9 @@
         padding-top: 1em;
         .kern();
         letter-spacing: 0.01em;
+
+        @media @bp-nav-full {       
+        }
     }
 
     li {
@@ -182,8 +185,6 @@
             ul {
                 height: 0;
                 overflow: hidden;
-                border-top: 1px solid #c00808;
-                border-top: 1px solid fadeout(#000,94%);
             }
 
             li {

--- a/wdn/templates_4.1/less/layouts/navigation.less
+++ b/wdn/templates_4.1/less/layouts/navigation.less
@@ -151,9 +151,6 @@
         padding-top: 1em;
         .kern();
         letter-spacing: 0.01em;
-
-        @media @bp-nav-full {       
-        }
     }
 
     li {

--- a/wdn/templates_4.1/less/layouts/navigation.less
+++ b/wdn/templates_4.1/less/layouts/navigation.less
@@ -131,7 +131,11 @@
 
         // Styles specific to the mobile view
         @media @bp-nav-hidden {
-            border-bottom: 1px solid @ui11;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+
+            &:hover {
+                border-bottom: 1px solid rgba(0, 0, 0, 0);
+            }
         }
 
         @media @bp-nav-full {

--- a/wdn/templates_4.1/less/layouts/search.less
+++ b/wdn/templates_4.1/less/layouts/search.less
@@ -117,7 +117,7 @@
 
     @media @bp-nav-hidden {
         position: absolute;
-	    left: 4.49em;
+	    left: 2.532em;
     }
 
     @media @bp-nav-full {
@@ -184,7 +184,7 @@
             content: '';
             position: absolute;
             top: -6px;
-            left: 5.61em;
+            left: 3.157em;
             width: 0;
             height: 0;
             border-left: 6px solid transparent;

--- a/wdn/templates_4.1/less/layouts/search.less
+++ b/wdn/templates_4.1/less/layouts/search.less
@@ -118,6 +118,7 @@
     @media @bp-nav-hidden {
         position: absolute;
 	    left: 2.532em;
+	    cursor: pointer;
     }
 
     @media @bp-nav-full {

--- a/wdn/templates_4.1/less/layouts/search.less
+++ b/wdn/templates_4.1/less/layouts/search.less
@@ -117,7 +117,7 @@
 
     @media @bp-nav-hidden {
         position: absolute;
-	    left: 2.532em;
+	    left: 2.369em;
 	    cursor: pointer;
     }
 

--- a/wdn/templates_4.1/less/layouts/share.less
+++ b/wdn/templates_4.1/less/layouts/share.less
@@ -55,7 +55,6 @@
 		    padding: 11px 0;
 			font-size: 17px;
 		    font-size: 1.069rem;
-			border-radius: 3px;
 
 			@media @bp-nav-hidden {
 	    		padding: 7px 0;

--- a/wdn/templates_4.1/less/layouts/share.less
+++ b/wdn/templates_4.1/less/layouts/share.less
@@ -52,13 +52,13 @@
 	    .wdn-icon-share {
 	    	display: block;
 	    	color: #fff;
-		    padding: 8px 0 10px 10px;
+		    padding: 11px 0;
 			font-size: 17px;
 		    font-size: 1.069rem;
 			border-radius: 3px;
 
 			@media @bp-nav-hidden {
-	    		padding: 7px 1.333em 7px 0;
+	    		padding: 7px 0;
 	    	}
 		}
 	}

--- a/wdn/templates_4.1/less/layouts/share.less
+++ b/wdn/templates_4.1/less/layouts/share.less
@@ -2,7 +2,7 @@
     z-index: (@nav-z-index + 1);
 
     @media @bp-nav-hidden {
-		margin-left: 1em;
+		margin-left: 4.209em;
     }
 
     @media @bp-nav-full {

--- a/wdn/templates_4.1/less/layouts/share.less
+++ b/wdn/templates_4.1/less/layouts/share.less
@@ -175,20 +175,26 @@
 }
 
 #navigation .wdn-icon-share {
-	position: relative;
-	left: 9px;
-	padding: 9px 0;
 	display: none;
 	cursor: pointer;
+	position: absolute;
+	padding: 9px 0;
 	line-height: normal;
+
+	@media @bp640 { right: @page-offset-640; }
+	@media @bp768 { right: @page-offset-768; }
+	@media @bp960 { right: @page-offset-960; }
+	@media @bp1280 { right: @page-offset-1280; }
+	@media @bp1600 { right: @page-offset-1600; }
+
+    @media @bp-nav-full {
+        display: inline-block;
+    }
 }
 
-@media @bp-nav-full {
-	.wdn-menu-trigger .wdn-share-button .wdn-icon-share {
-		display: none;
-	}
+.wdn-menu-trigger .wdn-share-button .wdn-icon-share {
 
-	#navigation .wdn-icon-share {
-		display: inline-block;
-	}
+    @media @bp-nav-full {
+	    display: none;
+    }
 }

--- a/wdn/templates_4.1/less/states/navigation.less
+++ b/wdn/templates_4.1/less/states/navigation.less
@@ -21,6 +21,17 @@
             }
         }
     }
+    
+    .nav_expanded & {
+        
+        > ul > li > a {
+
+            @media @bp-nav-full {
+                border-bottom: 1px solid #c00808;
+                border-bottom: 1px solid fadeout(#000,94%);
+            }            
+        }
+    }
 }
 
 @media @bp-nav-hidden {


### PR DESCRIPTION
Update UNL scarlet to #dd0000
Adjust layout of last-link breadcrumb
Adjust border-color for mobile navigation links
Position share widget on right edge of content instead of moving with navigations that have fewer than six primary links
Add border-bottom for primary navigation links without children