### PR TITLE
Share widget/mobile nav scrolling

### DIFF
--- a/wdn/templates_4.1/less/states/share.less
+++ b/wdn/templates_4.1/less/states/share.less
@@ -2,7 +2,6 @@
 .wdn-share-this-page {
 
     .nav-scrolling & {
-        position: fixed;
         z-index: (@nav-z-index + 1);
         top: 6px;
 


### PR DESCRIPTION
Share widget didn't move when user is scrolling and opens mobile nav tray. (It overlapped the breadcrumbs in the tray.) Removing position:fixed (which isn't needed anyway) fixes this behavior.