### PR TITLE
Scarlet band

### DIFF
--- a/wdn/templates_4.1/less/modules/bands.less
+++ b/wdn/templates_4.1/less/modules/bands.less
@@ -1,3 +1,7 @@
+.wdn-scarlet-band {
+    background: linear-gradient(to bottom, darken(@scarlet,3%), @scarlet);
+}
+
 .wdn-light-triad-band {
     .wdn-band(mix(@cream, @triad, 90%));
 }


### PR DESCRIPTION
Add support for band with scarlet background. This includes a subtle top-to-bottom linear gradient to help differentiate a scarlet band from the scarlet sticky navigation bar.