### PR TITLE
Fix a11y tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /wdn/templates_*/scripts/js-css/*.css
 /wdn/templates_*/scripts/plugins/qtip/wdn.qtip.css
 /wdn/templates_*/scripts/plugins/ui/css/jquery-ui-wdn.css
+/tests/config.inc.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 before_script: 
    # install `pa11y`
    - npm install
-   - npm install pa11y
+   - npm install pa11y@2.4.4
    - npm install grunt-cli
    # build the templates
    - ./node_modules/grunt-cli/bin/grunt

--- a/tests/Accessibility/accessibility.phpt
+++ b/tests/Accessibility/accessibility.phpt
@@ -5,13 +5,18 @@ Validate all example pages for accessibility
 //Load composer
 require_once dirname(__FILE__) . '/../../build/vendor/autoload.php';
 
+if (file_exists(__DIR__ . '/../config.inc.php')) {
+    require_once __DIR__ . '/../config.inc.php';
+}
+
 class AccessibilityTester {
     protected $examples_directory = '';
     protected $wrapper_html;
+    public static $base_url = 'http://localhost/';
     
     public function __construct()
     {
-        $this->examples_directory = dirname(__FILE__) . '/../../wdn/templates_4.0/examples/';
+        $this->examples_directory = dirname(__FILE__) . '/../../wdn/templates_4.1/examples/';
         $this->wrapper_html = file_get_contents($this->examples_directory . 'index.shtml');
     }
 
@@ -35,7 +40,7 @@ class AccessibilityTester {
      */
     protected function checkExample($file) {
         echo "checking: " . $file . PHP_EOL;
-        $url     = 'http://localhost/tests/Accessibility/tmp/' . $file . '.shtml';
+        $url = self::$base_url . 'tests/Accessibility/tmp/' . $file . '.shtml';
         $command = 'pa11y ' .
             '-r json ' .
             '-s WCAG2AA ' .
@@ -68,10 +73,12 @@ class AccessibilityTester {
     
         //Save to an example file.
         file_put_contents(__DIR__ . '/tmp/' . $file . '.shtml', \HTML5::saveHTML($new_dom));
-        
+
         //Run pa11y on the test page
-        $json = exec($command);
-    
+        $output_file =  __DIR__ . '/output.json';
+        $result = exec($command . ' > ' . $output_file);
+        $json = file_get_contents($output_file);
+
         if (!$data = json_decode($json, true)) {
             return false;
         }
@@ -80,8 +87,13 @@ class AccessibilityTester {
             if ($result['type'] != 'error') {
                 continue;
             }
-    
-            $errors[] = $result['code'] . ' -- ' . $result['context'];
+
+            $errors[] = $url
+                . "\r\n\t code: " . $result['code']
+                . "\r\n\t message: " . $result['message']
+                . "\r\n\t selector: " . $result['selector']
+                . "\r\n\t context: " . $result['context']
+                . "\r\n------------\r\n";
         }
     
         return $errors;

--- a/tests/Accessibility/accessibility.phpt
+++ b/tests/Accessibility/accessibility.phpt
@@ -44,6 +44,7 @@ class AccessibilityTester {
         $command = 'pa11y ' .
             '-r json ' .
             '-s WCAG2AA ' .
+            '-w 500 ' . 
             '--config ' . dirname(__FILE__) . '/pa11y.json ' . 
             '--htmlcs "http://webaudit.unl.edu/plugins/metric_pa11y/html_codesniffer/build/HTMLCS.js" ' .
             escapeshellarg($url);

--- a/tests/config.sample.php
+++ b/tests/config.sample.php
@@ -1,0 +1,2 @@
+<?php
+AccessibilityTester::$base_url = 'http://example.unl.edu/wdn_path/';

--- a/wdn/templates_4.1/less/layouts/footer.less
+++ b/wdn/templates_4.1/less/layouts/footer.less
@@ -165,6 +165,7 @@
 .wdn-footer-global {
 	padding: 3.157em 0 9.969em;
     color: @ui06;
+	background-color: @ui10;
 	background: @ui10 data-uri('../images/seal.svg') center bottom -14.204em no-repeat;
 	background-size: 25.24em 25.24em;
 


### PR DESCRIPTION
This should fix a11y tests that have been broken for 4.1.  (its a good thing I double checked them).

This also makes it easier to test without vagrant and improves the output of tests.