### PR TITLE
Adjust promo image background gradient

### DIFF
--- a/wdn/templates_4.1/less/modules/promo-image.less
+++ b/wdn/templates_4.1/less/modules/promo-image.less
@@ -12,7 +12,7 @@
 	top: 0;
 	bottom: 0;
 	width: 100%;
-	background-image: linear-gradient(top, rgba(0,0,0,0) 40%,rgba(0,0,0,0.5) 75%,rgba(0,0,0,0.3) 100%);
+	background-image: linear-gradient(rgba(0,0,0,0) 40%,rgba(0,0,0,0.5) 75%,rgba(0,0,0,0.3) 100%);
 
 	.wdn-promo-content {
 		position: absolute;


### PR DESCRIPTION
The default display of a CSS gradient is from top to bottom, therefore, the 'top' is not needed. When the vendor prefixes were removed, 'top' should have been removed, too.