### PR TITLE
A11y improvements

### DIFF
--- a/wdn/templates_4.1/includes/idm.html
+++ b/wdn/templates_4.1/includes/idm.html
@@ -2,7 +2,7 @@
     <a class="wdn-icon-user wdn-idm-login" href="https://login.unl.edu/cas/login" id="wdn_idm_username" title="Log in to UNL" accesskey="l">Login</a>
     <div id="wdn_idm_notice_container" class="wdn-dropdown-widget-content">
         <input type="checkbox" id="wdn_idm_toggle" class="wdn_idm_toggle wdn-input-driver wdn-dropdown-widget-toggle" aria-haspopup="true" aria-controls="wdn_idm_options" value="Show user profile options" />
-        <label for="wdn_idm_toggle" id="wdn_idm_toggle_label"></label>
+        <label for="wdn_idm_toggle" id="wdn_idm_toggle_label" class="hidden"></label>
         <nav id="wdn_idm_options" class="wdn-idm-options" aria-hidden="true">
             <ul>
                 <li><a href="https://planetred.unl.edu/" id="wdn_idm_profile">View Profile</a></li>

--- a/wdn/templates_4.1/includes/search.html
+++ b/wdn/templates_4.1/includes/search.html
@@ -4,6 +4,6 @@
     <form id="wdn_search_form" class="wdn-dropdown-widget-content" action="//www1.unl.edu/search/" method="get">
 		<label for="wdn_search_query">Search</label>
         <input required accesskey="f" id="wdn_search_query" name="q" type="search" />
-        <button type="submit" title="Search" class="wdn-icon-search"></button>
+        <button type="submit" class="wdn-icon-search"><span class="wdn-text-hidden">Search</span></button>
     </form>
 </div>

--- a/wdn/templates_4.1/scripts/idm.js
+++ b/wdn/templates_4.1/scripts/idm.js
@@ -234,6 +234,8 @@ define(['wdn', 'jquery', 'require'], function(WDN, $, require) {
 			$(toggleSel).css('backgroundImage', "url(" + planetRed + "icon/" + planetred_uid + "/medium/)")
                 .text(displayName(uid));
             $(profileSel).attr('href', planetRed + 'profile/' + planetred_uid);
+			
+			$(toggleSel).removeClass('hidden');
 
             // Hide login anchor
             $(userSel).hide();


### PR DESCRIPTION
When logged out, an empty `label` was available to the a11y api. Use best practices for buttons with no visible text for the search feature.