### PR TITLE
Search: Fix an issue where http request was being switched to https

### DIFF
--- a/wdn/templates_4.1/scripts/search.js
+++ b/wdn/templates_4.1/scripts/search.js
@@ -30,9 +30,9 @@ define(['jquery', 'wdn', 'require', 'modernizr', 'navigation'], function($, WDN,
 					submitted = false,
 					postReady = false,
 					autoSubmitTimeout,
-					searchHost = 'www1.unl.edu', // domain of UNL Search app
-					searchPath = '/search/', // path to UNL Search app
-					searchOrigin = window.location.protocol + '//' + searchHost,
+					searchHost = 'search.unl.edu', // domain of UNL Search app
+					searchPath = '/', // path to UNL Search app
+					searchOrigin = 'https://' + searchHost,
 					searchAction = searchOrigin + searchPath,
 					allowSearchParams = ['u', 'cx'],  // QS Params allowed by UNL Search app
 					siteHomepage = nav.getSiteHomepage(),


### PR DESCRIPTION
The first submit was fine, but after that, the origin would switch to https and thus break new submits. So if you started to type 'stephenie', it would submit a search for 'step' and then stop.