### PR TITLE
Fix home pages without home breadcrumb link lose nav on collapse

### DIFF
--- a/wdn/templates_4.1/scripts/navigation.js
+++ b/wdn/templates_4.1/scripts/navigation.js
@@ -191,8 +191,8 @@ define(['jquery', 'wdn', 'modernizr', 'require'], function($, WDN, Modernizr, re
 		}
 
 		if (!$homepageCrumbLink.length) {
-			$homepageCrumbLink = $('<a>', {href : siteHomepage});
-			$li.wrapInner($homepageCrumbLink);
+			$li.wrapInner($('<a>', {href : siteHomepage}));
+			$homepageCrumbLink = $li.children('a').eq(0);
 		}
 	};
 
@@ -358,7 +358,7 @@ define(['jquery', 'wdn', 'modernizr', 'require'], function($, WDN, Modernizr, re
 
 		$navList.children('li').removeClass(highlightClass);
 
-		if (breadcrumbParent.hasClass(selectedClass)) {
+		if (!breadcrumbParent.length || breadcrumbParent.hasClass(selectedClass)) {
 			WDN.log('already showing this nav');
 			return true;
 		}


### PR DESCRIPTION
The bug fix from b042326f856964ea9f6c6058b29ef9b0e88e860c
resolved the exception that was occurring in switchNavigation on
navigation collapse. However, it revealved that the variable reference
was not correct (after wrapInner does its magic). This caused an issue
where the active breadcurb (home navigation) could not be determined and
was removed when the navigation proxy returned a new home navigation
list.

A workaround for this issue would be to always have your home breadcrumb
be a link (as is required by the style guide).