### PR TITLE
Fix login link race condition

### DIFF
--- a/wdn/templates_4.1/scripts/idm.js
+++ b/wdn/templates_4.1/scripts/idm.js
@@ -248,6 +248,11 @@ define(['wdn', 'jquery', 'require'], function(WDN, $, require) {
 		},
 
 		displayLogin : function() {
+			if (Plugin.getUserId()) {
+				//if the user is already logged in, we should not reset the login
+				return;
+			}
+
 			var idm = $(mainSel),
 				loginLink = $(userSel);
 


### PR DESCRIPTION
It looks like there was a race condition. Website can set the login URL with JS, which will also cause `displayLogin()` to be called. `displayLogin()` would remove the `.loggedin` class from IDM container (but not remove the profile image, etc).  This would cause weird styling.

If a user is already logged in, the `displayLogin()` method should never be called, so prevent it from doing anything.