### PR TITLE
Text band margins

### DIFF
--- a/wdn/templates_4.1/less/layouts/bands.less
+++ b/wdn/templates_4.1/less/layouts/bands.less
@@ -16,8 +16,11 @@
 		.inner-wrapper-margin();
 
         .wdn-text-band& {
-        	max-width: 50rem;
-            margin: 0 auto;
+
+            @media @bp960 {
+        	    max-width: 50rem;
+                margin: 0 auto;
+            }
         }
 
         #maincontent & {


### PR DESCRIPTION
The text-band should be centered with a max-width of 50rem, but using margin: 0 auto; to center the content removes the left and right margins, resulting in text that runs right up to the viewport edge. This commit keeps the margins at narrower browser widths (where the length of the text never exceeds 50rem), and instead removes them and applies the 50rem max-width at 960px, where the viewport exceeds the width of the content and margins combined.