### PR TITLE
Hero content updates

### DIFF
--- a/wdn/templates_4.1/examples/hero.html
+++ b/wdn/templates_4.1/examples/hero.html
@@ -14,10 +14,14 @@
                     <a href="http://admissions.unl.edu/why-unl.aspx" class="wdn-button wdn-button-outline">Explore Admissions</a>
                 </div>
             </div>
-            <video class="wdn-hero-video" autoplay="" loop="" poster="samplecontent/2015-first-fb-game-wooooo.jpg">
-                <source src="samplecontent/2015-first-fb-game-fingers-crossed.mp4">
-            </video>
-            <img src="samplecontent/2015-first-fb-game-wooooo.jpg" alt="Students cheer at the football game" class="wdn-hero-poster">
+            <div class="wdn-hero-video">
+                <video autoplay="" loop="" poster="samplecontent/2015-first-fb-game-wooooo.jpg">
+                    <source src="samplecontent/2015-first-fb-game-fingers-crossed.mp4">
+                </video>
+            </div>
+            <div class="wdn-hero-picture">
+                <img src="samplecontent/2015-first-fb-game-wooooo.jpg" alt="Students cheer at the football game">
+            </div>
         </div>
     </div>
 </body>

--- a/wdn/templates_4.1/less/modules/hero.less
+++ b/wdn/templates_4.1/less/modules/hero.less
@@ -56,8 +56,7 @@
 }
 
 .wdn-hero-video,
-.wdn-hero-picture,
-.wdn-hero-poster {
+.wdn-hero-picture {
     order: 1;
     flex-shrink: 0;
     width: 100%;
@@ -142,6 +141,7 @@
     .wdn-hero-video,
     .wdn-hero-poster {
         opacity: .5;
+        overflow: hidden;
     }
 }
 

--- a/wdn/templates_4.1/less/modules/hero.less
+++ b/wdn/templates_4.1/less/modules/hero.less
@@ -67,21 +67,28 @@
     left: 0;
     display: none;
 
+    @media @bp768 {
+        display: block;
+    }
+
     .videoautoplay & {
         display: block;
     }
+
+    video {
+        width: 100%;
+    }
 }
 
-video ~ .wdn-hero-picture,
-video ~ .wdn-hero-poster {
+.wdn-hero-video ~ .wdn-hero-picture {
+
+    @media @bp768 {
+        display: none;
+    }
 
     .videoautoplay & {
         display: none;
     }
-}
-
-.wdn-hero-poster {
-    display: block;
 }
 
 // Media Queries


### PR DESCRIPTION
**Temporary Modernizr videoautoplay fallback**
As it turns out, the videoautoplay Modernizr test is [is not entirely reliable](Modernizr/Modernizr#1095). @mfairchild365 has submitted [a pull request](Modernizr/Modernizr#1963) to Modernizr which has been merged. In the meantime, I've adjusted the hero content CSS. The video will always play if the videoautoplay test works. If the test fails, we'll fall back to media queries. Video will be shown for browser widths greater than 768px.
**Markup and CSS updates to fix the broken navigation bug in Edge**
Markup and CSS updates to fix the broken navigation bug in Edge. By wrapping the image and video elements in parent containers and placing the overflow:hidden and opacity on the parents, the Edge bug is avoided. Fixes #983
