### PR TITLE
Remove the border from responsive embeds by default

### DIFF
--- a/wdn/templates_4.1/less/base/helpers.less
+++ b/wdn/templates_4.1/less/base/helpers.less
@@ -52,6 +52,7 @@
 	object, 
 	video,
 	.wdn-responsive-item {
+		border: 0;
 		position: absolute;
 		top: 0;
 		left: 0;


### PR DESCRIPTION
This will remove the need for inline styles on the iframe or use of the now invalid `frameborder` attribute 