### PR TITLE
Hero layout fixes

### DIFF
--- a/wdn/templates_4.1/less/modules/hero.less
+++ b/wdn/templates_4.1/less/modules/hero.less
@@ -139,7 +139,7 @@
     }
 
     .wdn-hero-video,
-    .wdn-hero-poster {
+    .wdn-hero-picture {
         opacity: .5;
         overflow: hidden;
     }

--- a/wdn/templates_4.1/less/modules/hero.less
+++ b/wdn/templates_4.1/less/modules/hero.less
@@ -82,6 +82,7 @@
 .wdn-hero-picture {
 
     img {
+        display: block;
         width: 100%;
     }
 }

--- a/wdn/templates_4.1/less/modules/hero.less
+++ b/wdn/templates_4.1/less/modules/hero.less
@@ -79,6 +79,13 @@
     }
 }
 
+.wdn-hero-picture {
+
+    img {
+        width: 100%;
+    }
+}
+
 .wdn-hero-video ~ .wdn-hero-picture {
 
     @media @bp768 {


### PR DESCRIPTION
* A media query still referenced .wdn-hero-poster, updated to .wdn-hero-picture
* Set wdn-hero-picture image width to 100%
* Set wdn-hero-picture image to display as a block, removing unwanted space below image, visible between 768–960px