### PR TITLE
Font styling updates

### DIFF
--- a/wdn/templates_4.1/less/base/text.less
+++ b/wdn/templates_4.1/less/base/text.less
@@ -9,10 +9,6 @@
     font-kerning: normal;
 }
 
-.ligatures() {
-    font-feature-settings: "liga" 1;
-}
-
 
 
 // !GENERAL

--- a/wdn/templates_4.1/less/base/text.less
+++ b/wdn/templates_4.1/less/base/text.less
@@ -6,7 +6,6 @@
 
 .kern() {
     font-feature-settings: "kern" 1;
-    font-kerning: normal;
 }
 
 

--- a/wdn/templates_4.1/less/layouts/forms.less
+++ b/wdn/templates_4.1/less/layouts/forms.less
@@ -67,7 +67,6 @@ form {
         width: 100%;
         .sans-serif-font();
         text-transform: uppercase;
-        .kern;
         white-space: normal;
         margin-bottom: 1em;
         padding-bottom: 0.339em;

--- a/wdn/templates_4.1/less/layouts/navigation.less
+++ b/wdn/templates_4.1/less/layouts/navigation.less
@@ -153,7 +153,6 @@
 
     > ul > li > a {
         padding-top: 1em;
-        .kern();
         letter-spacing: 0.01em;
     }
 

--- a/wdn/templates_4.1/less/layouts/noscript.less
+++ b/wdn/templates_4.1/less/layouts/noscript.less
@@ -24,7 +24,6 @@
     background-color: @warning;
     color: #000000;
     .sans-serif-font();
-    font-weight: bold;
     text-align: center;
     margin: 0;
     padding: 0 @mobile-pad;

--- a/wdn/templates_4.1/scripts/js-css/display-font.less
+++ b/wdn/templates_4.1/scripts/js-css/display-font.less
@@ -2,4 +2,5 @@
     font-family: 'Mercury Display A', 'Mercury Display B', Georgia, Baskerville, 'Baskerville Old Face', 'Hoefler Text', Garamond, 'Times New Roman', serif;
     font-weight: 400;
     font-style: normal;
+    font-feature-settings: 'kern' 1, 'liga' 1;
 }


### PR DESCRIPTION
- Remove ligatures from core webfonts (used only by Mercury Display)
- Update kerning and ligature CSS for Mercury Display
- Remove 'font-kerning' declaration
- Remove redundant kerning declarations
- Remove sans serif font weight bold
