### PR TITLE
Add bg-color to header

### DIFF
--- a/wdn/templates_4.1/less/layouts/header.less
+++ b/wdn/templates_4.1/less/layouts/header.less
@@ -1,3 +1,10 @@
+// !Header
+#header {
+    background-color: @cream;
+}
+
+
+
 // !Header, top line
 #wdn_header_top {
 	height: 30px; // temp


### PR DESCRIPTION
This will ensure that main content elements that are absolutely- or fixed-positioned won't appear behind the header if positioned at the top of the page.

As an example, Richard is using psuedo content to attach a fixed-position element with a background-image to his site for better scrolling performance and display consistency on mobile vs desktop: http://unlcms.unl.edu/businessandfinance/parking-2/welcome