### PR TITLE
WIP: Improve a11y for tabs

### DIFF
--- a/wdn/templates_4.1/scripts/tabs.js
+++ b/wdn/templates_4.1/scripts/tabs.js
@@ -101,7 +101,7 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 				var $panel = $('#'+getHashFromLink(this));
 
 				//If this tab doesn't have an id, give it one because we will need it later
-				if ('undefined' === typeof $tab.attr('id')) {
+				if (!this.id) {
 					$tab.attr('id', 'wdn-tab-for-'+$panel.attr('id'));
 				}
 

--- a/wdn/templates_4.1/scripts/tabs.js
+++ b/wdn/templates_4.1/scripts/tabs.js
@@ -94,12 +94,11 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 
 			var $tabs = $($tabsWithSwitch.find('a'));
 
-			$tabs.each(function(index, element) {
-				console.log(element);
-				var $tab = $(element);
+			$tabs.each(function() {
+				var $tab = $(this);
 
 				//Get the panel for this tab
-				var $panel = $('#'+getHashFromLink(element));
+				var $panel = $('#'+getHashFromLink(this));
 
 				//If this tab doesn't have an id, give it one because we will need it later
 				if ('undefined' === typeof $tab.attr('id')) {

--- a/wdn/templates_4.1/scripts/tabs.js
+++ b/wdn/templates_4.1/scripts/tabs.js
@@ -70,6 +70,28 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 		setupA11y = function ($tabsWithSwitch) {
 			$tabsWithSwitch.attr('role', 'tablist');
 
+			//Use arrow keys to focus tabs (standard tab interaction)
+			$tabsWithSwitch.on('keydown', function(event){
+				var key = event.keyCode;
+				var $tab = $(event.target);
+				var $tabContainer = $($tab.parent());
+				var target = false;
+
+				//Check if arrows were pressed
+				if (key >= 37 && key <= 40) {
+					if (key == 37 || key == 38) {
+						//Left or up arrow
+						target = $tabContainer.prev('li');
+					} else {
+						//right or down arrow
+						target = $tabContainer.next('li');
+					}
+
+					$(target).find('a').click();
+					event.preventDefault();
+				}
+			});
+
 			var $tabs = $($tabsWithSwitch.find('a'));
 
 			$tabs.each(function(index, element) {
@@ -98,30 +120,6 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 				
 				//Only make tabs pragmatically focusable by default
 				$tab.attr('tabindex', '-1');
-				
-				//Use arrow keys to focus tabs (standard tab interaction)
-				$tab.bind({
-					keydown: function(ev){
-						var k = ev.which || ev.keyCode;
-						var $tab = $(ev.target);
-						var $tabContainer = $($tab.parent());
-						var target = false;
-						
-						//Check if arrows were pressed
-						if (k >= 37 && k <= 40) {
-							if (k == 37 || k == 38) {
-								//Left or up arrow
-								target = $tabContainer.prev('li');
-							} else {
-								//right or down arrow
-								target = $tabContainer.next('li');
-							}
-
-							$(target).find('a').click();
-							ev.preventDefault();
-						}
-					}
-				});
 
 				//Tell the panel that it is a panel
 				$panel.attr('role', 'tabpanel');


### PR DESCRIPTION
This PR aims to improve a11y for tabs, specifically in regards to screen readers. It does the following:

- Applies appropriate roles to tab content such as `tablist`, `tab`, and `tabpanel`
- Replaces default keyboard navigation with the usual 'tab' navigation found in other UIs. In other words, it now uses arrow keys to cycle through tabs.

Issues that this solves
- SRs did not know that a list of links were 'tabs' or the relationship between tabs and tab panels
- SRs did not know which tab was currently selected
- SRs did not know the boundaries of tab panels (tab content)
- SR users that are familiar with tab UIs in non-browser environments expect to navigate the tabs with arrow keys. (this is news to me and there has been some debate around this, but I will defer to the experts).

Specifically this follows best practices as described by https://medium.com/@LeonieWatson/danger-testing-accessibility-with-real-people-4515f72db648 and http://a11y.nicolas-hoffmann.net/tabs/

This is a work in progress, but it is in a state that is appropriate for review. I still need to do some more testing before it gets merged. Feedback is welcome.