### PR TITLE
Toggle the container's aria-hidden attribute

### DIFF
--- a/wdn/templates_4.1/scripts/wdn-ui.js
+++ b/wdn/templates_4.1/scripts/wdn-ui.js
@@ -109,12 +109,14 @@ define(['jquery', 'modernizr'], function($, Modernizr) {
 
 			$(selector).change(function() {
 				var $control = $(this);
+				var container_id = $control.attr('aria-controls');
+				var $container = $('#'+container_id);
+				
 				if ($control.is(':checked')) {
-					var container_id = $control.attr('aria-controls');
-					var $container = $('#'+container_id);
 					$container.attr('aria-hidden', false);
 					$control.attr('aria-pressed', true);
 				} else {
+					$container.attr('aria-hidden', true);
 					$control.attr('aria-pressed', false);
 				}
 


### PR DESCRIPTION
The aria-hidden attribute was not being toggled correctly. Once it was set to `aria-hidden="false"` it would not be toggled back to `aria-hidden="true"`.