### PR TITLE
Figcaption styling updates

### DIFF
--- a/wdn/templates_4.1/less/modules/images.less
+++ b/wdn/templates_4.1/less/modules/images.less
@@ -13,6 +13,7 @@
         height: auto;
         padding: 0.5em;
         background-color: @page-background;
+        .sans-serif-font();
         .rem(10,12);
 
         * {

--- a/wdn/templates_4.1/less/modules/images.less
+++ b/wdn/templates_4.1/less/modules/images.less
@@ -13,7 +13,6 @@
         height: auto;
         padding: 0.5em;
         background-color: @page-background;
-        color: darken(@page-background, 75%);
         .rem(10,12);
 
         * {


### PR DESCRIPTION
Based on some recent suggestions:
- "suggest changing font color to match the body text color, the default color dark brown color #655114 doesn't go with any other default colors on the site"—Removed figcaption specific color, will inherit WDN HMTL color (#5b5b5a) instead
- "suggest changing font to a san-serif to make it easier to read since it's so tiny"—Changed figcaption to sans-serif font to further set it apart from serif body copy and bring it closer inline with the captions used on the recently-redesigned UNL Today.