### PR TITLE
Update example to encourage https

### DIFF
--- a/wdn/templates_4.1/examples/events.html
+++ b/wdn/templates_4.1/examples/events.html
@@ -7,7 +7,7 @@
 <body data-version="4.1">
     <div id="example-code">
         <script>
-            WDN.setPluginParam('events', 'href', '//events.unl.edu/');
+            WDN.setPluginParam('events', 'href', 'https://events.unl.edu/');
             WDN.setPluginParam('events', 'title', 'UNL');
         </script>
         <h2 class="sec_main"><abbr title="University of Nebraska&ndash;Lincoln">UNL</abbr> Calendar</h2>


### PR DESCRIPTION
HTTPS is getting to be required for Safari and IE sometimes, so let's stick that in the example to show users what to do.