### PR TITLE
Add Student Information Disclosures link to footer

### DIFF
--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -35,6 +35,7 @@
 				<li><a href="http://www.unl.edu/equity/" class="wdn-footer-list-item">Institutional Equity and Compliance</a></li>
 				<li><a href="http://www.unl.edu/equity/notice-nondiscrimination" class="wdn-footer-list-item">Notice of Nondiscrimination</a></li>
 				<li><a href="http://its.unl.edu/unlprivacypolicy" class="wdn-footer-list-item">Privacy Policy</a></li>
+				<li><a href="http://heoa.unl.edu/" class="wdn-footer-list-item">Student Information Disclosures</a></li>
 			</ul>
 
 			<a href="http://www.unl.edu/tips-incident-reporting-system/" id="tips_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">TIPS Incident Reporting</span></a>

--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -37,7 +37,6 @@
 				<li><a href="http://its.unl.edu/unlprivacypolicy" class="wdn-footer-list-item">Privacy Policy</a></li>
 				<li><a href="http://heoa.unl.edu/" class="wdn-footer-list-item">Student Information Disclosures</a></li>
 			</ul>
-
 			<a href="http://www.unl.edu/tips-incident-reporting-system/" id="tips_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">TIPS Incident Reporting</span></a>
 		</div>
 	</div>


### PR DESCRIPTION
Justin Chase Brown, Director of Scholarships & Financial Aid, emailed us to let us know that "[d]ue to HLC accreditation and federal regulations, our ‘student information disclosures’ must be positioned more prominently on the main UNL website." He asked that the title of the link be “Student Information Disclosures” and link to [http://heoa.unl.edu/](http://heoa.unl.edu/).