### PR TITLE
Improve promo-image layout

### DIFF
--- a/wdn/templates_4.1/less/modules/promo-image.less
+++ b/wdn/templates_4.1/less/modules/promo-image.less
@@ -25,23 +25,25 @@
 
     	.wdn-promo-text {
     		.heading-font;
-    		font-size: 41px;
-    		font-size: 3.154rem;
+    		font-size: 2.915rem;
+    		line-height: 1;
     		display: block;
+    		.inner-wrapper-margin();
 
     		@media @bp480 {
-	            font-size: 54px;
-	            font-size: 4.153rem;
+	            font-size: 3.116rem;
 	        }
 
 	        @media @bp768 {
-	            font-size: 72px;
 	            font-size: 4.499rem;
 	        }
 
 	        @media @bp960 {
-	            font-size: 89px;
 	            font-size: 5.61rem;
+	        }
+
+	        + a {
+                margin-top: 1em;
 	        }
     	}
 


### PR DESCRIPTION
I received feedback that the promo image layout has some issues: “Promo image text doesn't display well on mobile. It's too large and has too much line-height. It often overlaps the red nav bar on mobile. Can you make the text and line height smaller at the 480px breakpoint by default?”

This update:
* Reduces font-size for browser widths < 768px wide
* Removes pixel-based font-size fallbacks
* Specifies a line-height of 1
* Adds a left and right margin so text does not run to the edge of the browser chrome
* Adds margin-top to anchors (buttons) that immediately follow the promo text to provide adequate vertical space in between