### PR TITLE
Add a script to generate pages to help test hide-classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /wdn/templates_*/scripts/plugins/qtip/wdn.qtip.css
 /wdn/templates_*/scripts/plugins/ui/css/jquery-ui-wdn.css
 /tests/config.inc.php
+/tmp-*

--- a/debug.shtml
+++ b/debug.shtml
@@ -67,6 +67,7 @@
             <div id="maincontent" class="wdn-main">
                 <div id="pagetitle">
                     <!-- InstanceBeginEditable name="pagetitle" -->
+                    <h1>Debug Page</h1>
 	                <!-- InstanceEndEditable -->
                 </div>
                 <!-- InstanceBeginEditable name="maincontentarea" -->

--- a/scripts/generateHiddenRegionTests.php
+++ b/scripts/generateHiddenRegionTests.php
@@ -1,0 +1,21 @@
+<?php
+
+$page_to_copy = file_get_contents(__DIR__ . '/../debug.shtml');
+
+$hide_classes = [
+    'hide-wdn_institution_title',
+    'hide-wdn_identity_management',
+    'hide-breadcrumbs',
+    'hide-wdn_navigation_wrapper',
+    'hide-pagetitle',
+    'hide-wdn_footer_related',
+    'hide-wdn_footer_contact',
+    'hide-wdn_copyright',
+    'hide-wdn_attribution',
+    'hide-wdn_logos',
+];
+
+foreach ($hide_classes as $class) {
+    $page = str_ireplace('<body class="debug"', '<body class="debug '.$class.'"', $page_to_copy);
+    file_put_contents(__DIR__ . '/../tmp-'.$class.'.shtml', $page);
+}


### PR DESCRIPTION
This is a convenience script which generates pages that would help with manual testing of the hide-classes.

Just from reviewing these, it looks like some of the footer related ones still don't work. =/