### PR TITLE
Add a method to record mediahub iframe events to ga

### DIFF
--- a/wdn/templates_4.1/scripts/analytics.js
+++ b/wdn/templates_4.1/scripts/analytics.js
@@ -9,7 +9,9 @@ define(['wdn', 'idm', 'jquery'], function(WDN, idm, $) {
 		initd = false,
 
 		gaWdnName = 'wdn',
-		gaWdn = gaWdnName + '.';
+		gaWdn = gaWdnName + '.',
+		
+		mediaHubOrigin = 'https://mediahub.unl.edu';
 
 	var bindLinks = function() {
 		WDN.log('Begin binding links for analytics');
@@ -211,6 +213,28 @@ define(['wdn', 'idm', 'jquery'], function(WDN, idm, $) {
 			} catch (e) {
 				WDN.log("Timing tracking for local site didn't work.");
 			}
+		},
+		
+		recordMediaHubEvents: function() {
+			$(window).on('message', function(e) {
+				var originalEvent = e.originalEvent;
+				
+				if (mediaHubOrigin != originalEvent.origin) {
+					//Verify the origin
+					return;
+				}
+
+				if ('ga_event' != originalEvent.data.message_type) {
+					//not a ga event (maybe different event types in future?)
+					return;
+				}
+
+				Plugin.callTrackEvent(
+					'media',
+					originalEvent.data.event,
+					originalEvent.data.media_title
+				);
+			});
 		}
 	};
 


### PR DESCRIPTION
See https://github.com/unl/UNL_MediaHub/issues/319 and depends on https://github.com/unl/UNL_MediaHub/pull/322

To implement, a developer would have to do the following on every page which they want to record these events:
```
<script>
  require(['analytics'], function(analytics) {
    analytics.recordMediaHubEvents();
  });
</script>
```