### PR TITLE
Add min-height to WDN hero video and picture

### DIFF
--- a/wdn/templates_4.1/less/modules/hero.less
+++ b/wdn/templates_4.1/less/modules/hero.less
@@ -170,6 +170,7 @@
 
         .objectfit & {
             height: inherit;
+            min-height: 25.24em;
         }
     }
 }


### PR DESCRIPTION
At shorter heights, the picture or video would shrink and reveal the background-color of the hero container. This ensures that imagery always covers the hero container.