### PR TITLE
Mystery grid addition

### DIFF
--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -1,4 +1,4 @@
-<div class="wdn-grid-set bp480-wdn-grid-set-thirds bp960-wdn-grid-set-fourths">
+<div class="wdn-grid-set bp480-wdn-grid-set-thirds">
 	<div class="wdn-col">
 		<div class="wdn-footer-module wdn-footer-social">
 			<span role="heading">Connect with #UNL</span>


### PR DESCRIPTION
There are only 3 columns in the global footer. There is never a reason to make the spacing strange by switching to a 4 col layout with only 3 cols.