### PR TITLE
Update Big Ten logo link to Academic Partnerships

### DIFF
--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -48,7 +48,7 @@
 				<div class="bp640-wdn-col-one-third">
     				<div id="nebraska-b1g-lockup">
                         <a href="http://www.unl.edu/" id="footer_n_logo" class="wdn-footer-logo"><span class="wdn-text-hidden">University of Nebraska&ndash;Lincoln</span></a>
-                        <a href="http://www.unl.edu/about/big-ten/" id="b1g_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">About the Big Ten Conference</span></a>
+                        <a href="http://www.unl.edu/about/academic-partnerships/" id="b1g_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">About the Big Ten Conference</span></a>
                     </div>
 				</div>
 				<div class="bp640-wdn-col-two-thirds">


### PR DESCRIPTION
The ‘About the Big Ten Conference’ page has been renamed ‘Academic Partnerships.’ The content wasn’t exclusively about the Big Ten Conference, but also included content about the Big Ten Academic Alliance and Association of Public and Land-Grant Universities (APLU). The URL has been updated to reflect the new name. Likewise, I’m updating the link in the global footer.