### PR TITLE
Remove animated caption

### DIFF
--- a/wdn/templates_4.1/less/modules/images.less
+++ b/wdn/templates_4.1/less/modules/images.less
@@ -22,24 +22,3 @@
         }
     }
 }
-
-.wdn-caption-animate {
-    position: relative;
-    overflow: hidden;
-
-    img {
-        transition: transform .4s;
-    }
-
-    figcaption {
-        position: absolute;
-        min-height: 50px;
-        width: 100%;
-        bottom: 0;
-        opacity: .5;
-
-        // animation support
-        transform: translateY(90%);
-        transition: transform .4s, opacity .3s .1s;
-    }
-}


### PR DESCRIPTION
aXe reports the opacity of the figcaption in the [animated caption](http://wdn.unl.edu/images) as an error. While adjusting the opacity could resolve it, this error shines a light on other problems with this design pattern. The caption is hidden by default and shown only on hover, leaving no way to access the content on devices that don't support hover events (i.e. touch screens). Unless there is a focusable item in the figcaption, this content will also not be keyboard accessible. We should strive to show content by default and hide it only when there's a demonstrated need. That need should then be addressed with an interface that makes the reason for—and interactions with—hidden content clear to the user.

Despite working ok for me, @mfairchild365 has found that the caption does not animate for him in Chrome 55. While removal of the animated caption should make this a moot point, I will follow up with Michael about the inconsistent functionality.