### PR TITLE
Decrease hero text-shadow

### DIFF
--- a/wdn/templates_4.1/less/modules/hero.less
+++ b/wdn/templates_4.1/less/modules/hero.less
@@ -35,7 +35,7 @@
 
 .wdn-hero-initial-line,
 .wdn-hero-impact-line {
-    text-shadow: 1px 1px 54px fadeout(#000,50%);
+    text-shadow: 1px 1px 16px fadeout(#000,50%);
 }
 
 .wdn-hero-initial-line {


### PR DESCRIPTION
Despite clearing my history, I continue to see unwanted artifacts in the hero text-shadow in Chrome—both while logged in _and_ out of UNLcms. Even if it is just me, the smaller text-shadow will provide a bit more contrast around letters instead of being more diffused.

<img width="562" alt="Screen shot of hero text-shadow artifacts" src="https://cloud.githubusercontent.com/assets/5385125/22167414/c912bb3e-df2b-11e6-93da-8f5c2262ad31.png">
.