### PR TITLE
Add vertical space between main content and footer

### DIFF
--- a/wdn/templates_4.1/less/layouts/bands.less
+++ b/wdn/templates_4.1/less/layouts/bands.less
@@ -1,6 +1,14 @@
-// implement the same content padding
-#maincontent > * {
-	.inner-wrapper-margin();
+#maincontent {
+
+    // implement the same content padding
+    > * {
+	    .inner-wrapper-margin();
+    }
+
+    // Add margin to last element (if not a .wdn-band) to add vertical space between main content and footer
+    > *:last-child:not(.wdn-band) {
+        margin-bottom: 2.369rem;
+    }
 }
 
 .wdn-band {


### PR DESCRIPTION
Add margin-bottom to last-child element (if not a .wdn-band) of #maincontent to add vertical space between main content and footer.

If someone can think of a better way of doing this, I'm all ears.