### PR TITLE
 carousel: Disable The direction nav by default

### DIFF
--- a/wdn/templates_4.1/scripts/carousel.js
+++ b/wdn/templates_4.1/scripts/carousel.js
@@ -18,9 +18,15 @@ define([
 	return {
 		initialize : function(callback) {
 			$(function() {
-				var defaults = WDN.getPluginParam('carousel', 'defaults') || {};
+				var userConfig = WDN.getPluginParam('carousel', 'defaults') || {};
+				var defaultConfig = {
+                    directionNav: false
+				};
+
+				var localConfig = $.extend({}, defaultConfig, userConfig);
+				
 				$(defaultSel).addClass(flexCls);
-				$('.' + flexCls).flexslider(defaults);
+				$('.' + flexCls).flexslider(localConfig);
 				initd = true;
 				
 				if (callback) {


### PR DESCRIPTION
The direction nav fails accessibility audits by default because in its 'hidden' state, the navigation is still in the DOM and focusable. However, when focused with a keyboard, they are not shown, and thus can cause confusion (where is the current focus?). Additionally, the animation to show them on hover floats them in from the sides and can create a confusing and moving click target. Let's just disable them for now.