### PR TITLE
Force events widgets to use https to retrieve events

### DIFF
--- a/wdn/templates_4.1/scripts/events-band.js
+++ b/wdn/templates_4.1/scripts/events-band.js
@@ -19,7 +19,7 @@ define([
     },
 
     container = '#events-band',
-    defaultCal = '//events.unl.edu/';
+    defaultCal = 'https://events.unl.edu/';
 
     var fetchEvents = function(localConfig) {
         var upcoming = 'upcoming/',
@@ -93,6 +93,13 @@ define([
             rooms: false
         },
         localConfig = $.extend({}, defaultConfig, config);
+
+        // ensure that the URL we are about to use is forced into an https:// protocol. (add https if it starts with //)
+        if (localConfig.url && localConfig.url.match(/^\/\//)) {
+            localConfig.url = 'https:' + localConfig.url;
+        } else if (localConfig.url && localConfig.url.match(/^http:\/\//)) {
+            localConfig.url = localConfig.url.replace('http://', 'https://');
+        }
 
         if (localConfig.url && $(localConfig.container).length) {
             fetchEvents(localConfig);

--- a/wdn/templates_4.1/scripts/events.js
+++ b/wdn/templates_4.1/scripts/events.js
@@ -18,7 +18,7 @@ define([
 		return eventParams || {};
 	},
 	container = '#wdn_calendarDisplay',
-	defaultCal = '//events.unl.edu/';
+	defaultCal = 'https://events.unl.edu/';
 
 	var display = function(data, config) {
 		var $container = $(config.container).addClass('wdn-calendar');
@@ -96,6 +96,13 @@ define([
 			rooms: false
 		},
 		localConfig = $.extend({}, defaultConfig, config);
+
+		// ensure that the URL we are about to use is forced into an https:// protocol. (add https if it starts with //)
+        if (localConfig.url && localConfig.url.match(/^\/\//)) {
+            localConfig.url = 'https:' + localConfig.url;
+        } else if (localConfig.url && localConfig.url.match(/^http:\/\//)) {
+            localConfig.url = localConfig.url.replace('http://', 'https://');
+        }
 
 		if (localConfig.url && $(localConfig.container).length) {
 			$(this.container).addClass('wdn-calendar');

--- a/wdn/templates_4.1/scripts/monthwidget.js
+++ b/wdn/templates_4.1/scripts/monthwidget.js
@@ -21,7 +21,7 @@ define([
 		return eventParams || {};
 	},
 	container = '#monthwidget',
-	defaultCal = '//events.unl.edu/';
+	defaultCal = 'https://events.unl.edu/';
 
 	var display = function(data, config) {
 		var $container = $(config.container);
@@ -108,6 +108,13 @@ define([
 			container: container
 		},
 		localConfig = $.extend({}, defaultConfig, config);
+
+		// ensure that the URL we are about to use is forced into an https:// protocol. (add https if it starts with //)
+        if (localConfig.url && localConfig.url.match(/^\/\//)) {
+            localConfig.url = 'https:' + localConfig.url;
+        } else if (localConfig.url && localConfig.url.match(/^http:\/\//)) {
+            localConfig.url = localConfig.url.replace('http://', 'https://');
+        }
 
 		if (localConfig.url && $(localConfig.container).length) {
 			$.get(localConfig.url + '?monthwidget&format=hcalendar', function(data) {


### PR DESCRIPTION
Safari, mobile Safari, and occasionally IE/Edge (some versions)
would not correctly upgrade requests to the UNL Events API
to https. This would cause a CSRF warning and the request would
fail, causing the events widget not to appear. The problem was
fixed by the user entering https:// before their calendar URL
as opposed to just //, but this patch forces https:// if the
user had the old way put in.

Fixes card
https://trello.com/c/7c3VGIvp/60-events-widget-force-https-urls-for-parameters-in-the-widget