### PR TITLE
Fix: Adding focus for events-band

### DIFF
--- a/wdn/templates_4.1/scripts/js-css/events-band.less
+++ b/wdn/templates_4.1/scripts/js-css/events-band.less
@@ -89,7 +89,6 @@
         }
 
         .dateTime {
-            background-color: @events-darkblue;
             background-color: fadeout(#000, 60%);
             float: left;
             text-align: center;

--- a/wdn/templates_4.1/scripts/js-css/events-band.less
+++ b/wdn/templates_4.1/scripts/js-css/events-band.less
@@ -1,6 +1,8 @@
 @import '../../less/_mixins/all.less';
 
 @events-blue: #0e60a0;
+@events-darkblue: #0c3e65;
+@events-darkbluegray: #3f5565;
 
 #events-band,
 .wdn-events-band {
@@ -42,9 +44,28 @@
         outline: none;
 
         &:hover {
-
             .event {
                 background-color: @events-blue;
+            }
+        }
+
+        &:focus {
+            .event {
+                background-color: @events-darkbluegray;
+
+                .dateTime {
+                    background-color: darken(@events-darkbluegray,9%);
+
+                    .time {
+                        color: lighten(@events-blue, 40%);
+                    }
+                }
+
+                .eventInfo {
+                    .location {
+                        color: lighten(@events-blue, 40%);
+                    }
+                }
             }
         }
     }
@@ -68,7 +89,7 @@
         }
 
         .dateTime {
-            background-color: #0c3e65;
+            background-color: @events-darkblue;
             background-color: fadeout(#000, 60%);
             float: left;
             text-align: center;
@@ -134,6 +155,12 @@
 
         a {
             justify-content: flex-end;
+
+            &:focus {
+                display: inline-block;
+                padding: 0 2px;
+                outline: 1px dotted;
+            }
         }
     }
 }

--- a/wdn/templates_4.1/scripts/js-css/events-band.less
+++ b/wdn/templates_4.1/scripts/js-css/events-band.less
@@ -1,8 +1,7 @@
 @import '../../less/_mixins/all.less';
 
-@events-blue: #0e60a0;
-@events-darkblue: #0c3e65;
-@events-darkbluegray: #3f5565;
+@events-color--default: #0e60a0;
+@events-color--focus: #3f5565;
 
 #events-band,
 .wdn-events-band {
@@ -45,25 +44,23 @@
 
         &:hover {
             .event {
-                background-color: @events-blue;
+                background-color: @events-color--default;
             }
         }
 
         &:focus {
             .event {
-                background-color: @events-darkbluegray;
+                background-color: darken(@events-color--focus,3.5%);
 
                 .dateTime {
-                    background-color: darken(@events-darkbluegray,9%);
-
                     .time {
-                        color: lighten(@events-blue, 40%);
+                        color: lighten(@events-color--default, 40%);
                     }
                 }
 
                 .eventInfo {
                     .location {
-                        color: lighten(@events-blue, 40%);
+                        color: lighten(@events-color--default, 40%);
                     }
                 }
             }
@@ -77,7 +74,7 @@
         padding: 0;
         transition: background-color .3s ease; // lesshat
         overflow: hidden;
-        background-color: lighten(@events-blue, 5%);
+        background-color: lighten(@events-color--default, 5%);
 
         .dateTime,
         .eventInfo {
@@ -119,7 +116,7 @@
                     font-size: 1rem; // 12.83px, 16px
                     line-height: 1.333;
                     letter-spacing: .08em;
-                    color: lighten(@events-blue, 50%);
+                    color: lighten(@events-color--default, 50%);
                 }
             }
         }
@@ -142,7 +139,7 @@
                 text-transform: uppercase;
                 letter-spacing: .08em;
                 line-height: 1.425;
-                color: lighten(@events-blue, 66%);
+                color: lighten(@events-color--default, 66%);
             }
         }
     }


### PR DESCRIPTION
Outline was set to zero for events-band links (cards) with no alternative styles provided for when they are in focus. [Resource](http://www.outlinenone.com/)

-Added focus styles to event band links including view more events link at the bottom of the band.
-Added two color variables in events-band.less: @events-darkblue, and @events-darkbluegray

Changes to be committed:
	modified:   wdn/templates_4.1/scripts/js-css/events-band.less