### PR TITLE
Table color improvements

### DIFF
--- a/wdn/templates_4.1/less/layouts/tables.less
+++ b/wdn/templates_4.1/less/layouts/tables.less
@@ -17,7 +17,6 @@ table {
         font-size: .9353rem; // 12px
         padding: 1.2307em 1.0833em 1.0833em;
         line-height: 1.333;
-        border-top: 1px solid @ui04;
         background-color: darken(@ui01, 2%);
     }
 
@@ -55,6 +54,7 @@ table {
 }
 
 table.wdn_responsive_table {
+    border-collapse: separate;
 
     thead tr {
         display: none;
@@ -68,15 +68,9 @@ table.wdn_responsive_table {
 
     tbody {
 
-        tr {
-
-            &:first-child th {
-                border-top-width: 0;
-            }
-        }
-
         th {
             text-align: left;
+            border-top: 1px solid @ui04;
         }
 
         td {
@@ -111,6 +105,10 @@ table.wdn_responsive_table {
         tbody {
 
             tr {
+
+                &:first-child th {
+                    border-top-width: 0;
+                }
 
                 &:nth-of-type(even) {
                     background-color: transparent;
@@ -151,13 +149,6 @@ table.wdn_responsive_table {
         }
 
         tbody {
-
-            tr {
-
-                &:first-child th {
-                    border-top-width: 1px;
-                }
-            }
 
             td {
                 text-align: center;

--- a/wdn/templates_4.1/less/layouts/tables.less
+++ b/wdn/templates_4.1/less/layouts/tables.less
@@ -5,19 +5,11 @@ table {
     .base-font();
     border: 1px solid @ui04;
 
-    @media @bp768 {
-        line-height: @base-line-height-lg;
-    }
-
     caption {
         .brand-font();
         font-size: 2.954rem; // 37.897px
         line-height: 1;
         margin-bottom: .75em;
-
-        @media @bp768 {
-            font-size: 2.532rem; // 40.51px
-        }
     }
 
     th {
@@ -27,28 +19,22 @@ table {
         line-height: 1.333;
         border-top: 1px solid @ui04;
         background-color: darken(@ui01, 2%);
-
-        @media @bp768 {
-            padding: 1.2307em 1.2307em 1em;
-            font-size: .802rem; // 12.83px
-        }
     }
 
-    th, td {
+    th,
+    td {
         text-align: left;
     }
 
     td {
         font-weight: normal;
         padding: .92307em 1em .7692em;
-
-        @media @bp768 {
-            padding: .75em 1em .602em;
-        }
     }
 
     tbody {
+
         tr {
+
             &:nth-of-type(even) {
                 background-color: @ui01;
             }
@@ -69,37 +55,23 @@ table {
 }
 
 table.wdn_responsive_table {
+
     thead tr {
         display: none;
-
-        @media @bp768 {
-            display: table-row;
-        }
     }
 
-    th, td {
+    th,
+    td {
         text-align: center;
         display: block;
-
-        @media @bp768 {
-            display: table-cell;
-        }
     }
 
     tbody {
+
         tr {
-            @media @bp-under768w {
-                &:nth-of-type(even) {
-                    background-color: transparent;
-                }
-            }
 
             &:first-child th {
                 border-top-width: 0;
-
-                @media @bp768 {
-                    border-top-width: 1px;
-                }
             }
         }
 
@@ -110,33 +82,94 @@ table.wdn_responsive_table {
         td {
             text-align: left;
 
-            @media @bp768 {
-                text-align: center;
-            }
-
             &:before {
                 display: block;
                 font-weight: bold;
                 content: attr(data-header);
-
-                @media @bp768 {
-                    display: none !important;
-                }
             }
 
             &:empty {
                 display: none;
-
-                @media @bp768 {
-                    display: table-cell;
-                }
             }
         }
     }
 
     &.flush-left {
-        th, td {
+
+        th,
+        td {
             text-align: left;
+        }
+    }
+}
+
+
+@media @bp-under768w {
+
+    table.wdn_responsive_table {
+
+        tbody {
+
+            tr {
+
+                &:nth-of-type(even) {
+                    background-color: transparent;
+                }
+            }
+        }
+    }
+}
+
+@media @bp768 {
+
+    table {
+        line-height: @base-line-height-lg;
+
+        caption {
+            font-size: 2.532rem; // 40.51px
+        }
+
+        th {
+            padding: 1.2307em 1.2307em 1em;
+            font-size: .802rem; // 12.83px
+        }
+
+        td {
+            padding: .75em 1em .602em;
+        }
+    }
+
+    table.wdn_responsive_table {
+
+        thead tr {
+            display: table-row;
+        }
+
+        th,
+        td {
+            display: table-cell;
+        }
+
+        tbody {
+
+            tr {
+
+                &:first-child th {
+                    border-top-width: 1px;
+                }
+            }
+
+            td {
+                text-align: center;
+
+                &:before {
+                    display: none !important;
+                }
+
+                &:empty {
+                    display: table-cell;
+                }
+            }
         }
     }
 }

--- a/wdn/templates_4.1/less/modules/tables.less
+++ b/wdn/templates_4.1/less/modules/tables.less
@@ -1,214 +1,310 @@
-table.primary {
-    /* Primary Table */
-    border: none;
+table.primary,
+table.cool,
+table.soothing,
+table.neutral,
+table.energetic {
 
-    thead {
-        border: 1px solid fadeout(@brand,20%);
-    }
-
-    tr th {
+    th {
         color: #fff;
-        background: fadeout(@brand,20%);
-        border-top: none;
-        border-bottom: 3px solid darken(@brand,10%);
 
         a {
             color: #fff;
         }
     }
+}
+
+table.primary {
+    /* Primary Table */
+    border-color: lighten(@brand,50%);
+
+    th {
+        background-color: fadeout(@brand,20%);
+    }
 
     tbody {
-        border: 1px solid lighten(@brand,50%);
-
-        tr {
-
-            &:nth-of-type(even) {
-                background-color: lighten(@brand,58%);
-            }
-        }
 
         td {
             border-color: lighten(@brand,50%);
+
+            &:first-child {
+                color: darken(@brand,10%);
+            }
         }
-    }
-
-    @media @bp-under768w {
-
-	    &.wdn_responsive_table tbody td:first-child {
-            color: #fff;
-            background: fadeout(@brand,20%);
-    	}
     }
 }
 
 table.cool {
     /* Cool Table */
-    border: none;
+    border-color: lighten(@dark-triad,45%);
 
-    thead {
-        border: 1px solid @triad;
-    }
-
-    tr th {
-        color: #fff;
-        background: @triad;
-        border-top: none;
-        border-bottom: 3px solid darken(@triad,5%);
-
-        a {
-            color: #fff;
-        }
+    th {
+        background-color: @triad;
     }
 
     tbody {
-        border: 1px solid lighten(@dark-triad,45%);
-
-        tr {
-
-            &:nth-of-type(even) {
-                background-color: lighten(@dark-triad,58%);
-            }
-        }
 
         td {
             border-color: lighten(@dark-triad,45%);
-        }
-    }
 
-    @media @bp-under768w {
-
-        &.wdn_responsive_table tbody td:first-child {
-            color: darken(@light-triad,70%);
-            background: fadeout(@light-triad,20%);
+            &:first-child {
+                color: darken(@triad,10%);
+            }
         }
     }
 }
 
 table.soothing {
     /* Soothing Table */
-    border: none;
+    border-color: lighten(@dark-complement,50%);
 
-    thead {
-        border: 1px solid @complement;
-    }
-
-    tr th {
-        color: #fff;
-        background: @complement;
-        border-top: none;
-        border-bottom: 3px solid darken(@complement,5%);
-
-        a {
-            color: #fff;
-        }
+    th {
+        background-color: @complement;
     }
 
     tbody {
-        border: 1px solid lighten(@dark-complement,50%);
-
-        tr {
-
-            &:nth-of-type(even) {
-                background-color: lighten(@dark-complement,64%);
-            }
-        }
 
         td {
             border-color: lighten(@dark-complement,50%);
-        }
-    }
 
-    @media @bp-under768w {
-
-		&.wdn_responsive_table tbody td:first-child {
-            color: #fff;
-            background: fadeout(@dark-complement,20%);
+            &:first-child {
+                color: darken(@complement,10%);
+            }
         }
     }
 }
 
 table.neutral {
     /* Neutral Table */
-    border: none;
+    border-color: lighten(@dark-neutral,60%);
 
-    thead {
-        border: 1px solid fadeout(@neutral,20%);
-    }
-
-    tr th {
-        color: #fff;
-        background: fadeout(@neutral,20%);
-        border-top: none;
-        border-bottom: 3px solid @dark-neutral;
-
-        a {
-            color: #fff;
-        }
+    th {
+        background-color: fadeout(@neutral,15%);
     }
 
     tbody {
-        border: 1px solid lighten(@dark-neutral,60%);
-
-        tr {
-
-            &:nth-of-type(even) {
-                background-color: lighten(@dark-neutral,75%);
-            }
-        }
 
         td {
             border-color: lighten(@dark-neutral,60%);
-        }
-    }
 
-    @media @bp-under768w {
-
-		&.wdn_responsive_table tbody td:first-child {
-            color: @dark-neutral;
-            background: fadeout(@neutral,20%);
+            &:first-child {
+                color: @neutral;
+            }
         }
     }
 }
 
 table.energetic {
     /* Energetic Table */
-    border: none;
+    border-color: lighten(@dark-energetic,44%);
 
-    thead {
-        border: 1px solid @energetic;
-    }
-
-    tr th {
-        color: #fff;
-        background: @energetic;
-        border-top: none;
-        border-bottom: 3px solid darken(@energetic,5%);
-
-        a {
-            color: #fff;
-        }
+    th {
+        background-color: @energetic;
     }
 
     tbody {
-        border: 1px solid lighten(@dark-energetic,44%);
-
-        tr {
-
-            &:nth-of-type(even) {
-                background-color: lighten(@dark-energetic,55%);
-            }
-        }
 
         td {
             border-color: lighten(@dark-energetic,44%);
+
+            &:first-child {
+                color: darken(@energetic,10%);
+            }
+        }
+    }
+}
+
+@media @bp-under768w {
+
+    table.wdn_responsive_table.primary,
+    table.wdn_responsive_table.cool,
+    table.wdn_responsive_table.soothing,
+    table.wdn_responsive_table.neutral,
+    table.wdn_responsive_table.energetic {
+
+        tbody {
+
+            th {
+                border-color: transparent;
+            }
         }
     }
 
-    @media @bp-under768w {
+    table.wdn_responsive_table {
 
-		&.wdn_responsive_table tbody td:first-child {
-            color: #000;
-            background: fadeout(@dark-energetic,20%);
+        &.primary {
+
+            tbody {
+
+                td:nth-of-type(even) {
+                    background-color: lighten(@brand,58%);
+                }
+            }
+        }
+
+        &.cool {
+
+            tbody {
+
+                td:nth-of-type(even) {
+                    background-color: lighten(@dark-triad,58%);
+                }
+            }
+        }
+
+        &.soothing {
+
+            tbody {
+
+                td:nth-of-type(even) {
+                    background-color: lighten(@dark-complement,64%);
+                }
+            }
+        }
+
+        &.neutral {
+
+            tbody {
+
+                td:nth-of-type(even) {
+                    background-color: lighten(@dark-neutral,75%);
+                }
+            }
+        }
+
+        &.energetic {
+
+            tbody td {
+
+                td:nth-of-type(even) {
+                    background-color: lighten(@dark-energetic,55%);
+                }
+            }
+        }
+    }
+}
+
+@media @bp768 {
+
+    table.wdn_responsive_table.primary,
+    table.wdn_responsive_table.cool,
+    table.wdn_responsive_table.soothing,
+    table.wdn_responsive_table.neutral,
+    table.wdn_responsive_table.energetic {
+
+        tbody {
+
+            tr {
+
+                &:first-of-type {
+
+                    th {
+                        border-color: transparent;
+                    }
+                }
+            }
+        }
+    }
+
+    table.wdn_responsive_table {
+
+        &.primary {
+
+            tbody {
+
+                tr {
+
+                    &:nth-of-type(even) {
+                        background-color: lighten(@brand,58%);
+                    }
+
+                    &:not(:first-of-type) {
+
+                        th {
+                            border-color: darken(@brand,5%);
+                        }
+                    }
+                }
+            }
+        }
+
+        &.cool {
+
+            tbody {
+
+                tr {
+
+                    &:nth-of-type(even) {
+                        background-color: lighten(@dark-triad,58%);
+                    }
+
+                    &:not(:first-of-type) {
+
+                        th {
+                            border-color: darken(@triad,7%);
+                        }
+                    }
+                }
+            }
+        }
+
+        &.soothing {
+
+            tbody {
+
+                tr {
+
+                    &:nth-of-type(even) {
+                        background-color: lighten(@dark-complement,64%);
+                    }
+
+                    &:not(:first-of-type) {
+
+                        th {
+                            border-color: darken(@complement,5%);
+                        }
+                    }
+                }
+            }
+        }
+
+        &.neutral {
+
+            tbody {
+
+                tr {
+
+                    &:nth-of-type(even) {
+                    	background-color: lighten(@dark-neutral,75%);
+                    }
+
+                    &:not(:first-of-type) {
+
+                        th {
+                            border-color: lighten(@neutral,2%);
+                        }
+                    }
+                }
+            }
+        }
+
+        &.energetic {
+
+            tbody {
+
+                tr {
+
+                    &:nth-of-type(even) {
+                    	background-color: lighten(@dark-energetic,55%);
+                    }
+
+                    &:not(:first-of-type) {
+
+                        th {
+                            border-color: darken(@energetic,6%);
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Some table colors did not meet color contrast compliance. The colors, background-colors, and border colors have been adjusted.

Table zebra-striping has been improved for @bp-under768w by applying alternating stripes directly to the stacking <td> cells… 
<img width="512" alt="screen shot 2017-04-05 at 8 22 23 pm" src="https://cloud.githubusercontent.com/assets/5385125/24733728/eb04eafc-1a3e-11e7-94ff-245cffea54be.png">
…instead of to the table rows.
<img width="504" alt="screen shot 2017-04-05 at 8 09 47 pm" src="https://cloud.githubusercontent.com/assets/5385125/24733738/032bffee-1a3f-11e7-96cb-2cc4fbd60cab.png">

Border-collapse has been set to separate for responsive tables. Dark borders were overlapping lighter borders:
<img width="703" alt="screen shot 2017-04-05 at 6 02 57 pm" src="https://cloud.githubusercontent.com/assets/5385125/24733703/c41294a8-1a3e-11e7-9aa3-0f42b1732af1.png">

This pull request also includes some general code cleanup.

Fixes #1056.