### PR TITLE
Include speedy_body_scripts.html in smudge list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 Templates/*.dwt* filter=rcs-keywords
 wdn/templates_*/includes/scriptsandstyles*.html filter=rcs-keywords
+wdn/templates_*/includes/speedy_body_scripts.html filter=rcs-keywords

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,8 @@ module.exports = function (grunt) {
 	// files for keyword replacement (should match .gitattributes)
 	var filterFiles = [
 		templateHtmlDir + '/*.dwt*',
-		templateIncludeDir + '/scriptsandstyles*.html'
+		templateIncludeDir + '/scriptsandstyles*.html',
+		templateIncludeDir + '/speedy_body_scripts.html'
 	];
 
 	// polyfill modules that need sync loading (should match scripts loaded in debug.js)


### PR DESCRIPTION
The new speedy_body_scripts.html file has [a reference](https://github.com/unl/wdntemplates/blob/d3e664238da799768352de2692e92897cff7c8b7/wdn/templates_4.1/includes/speedy_body_scripts.html#L1) to the `DEP_VERSION` keyword and needs to be handled specially when building releases.  This commit adds it to the list of candidates for keyword replacement.