### PR TITLE
Restore button cursor lost in normalize.css update

### DIFF
--- a/wdn/templates_4.1/less/layouts/forms.less
+++ b/wdn/templates_4.1/less/layouts/forms.less
@@ -1,5 +1,5 @@
 button,
-html [type="button"],
+[type="button"],
 [type="reset"],
 [type="submit"] {
     cursor: pointer;

--- a/wdn/templates_4.1/less/layouts/forms.less
+++ b/wdn/templates_4.1/less/layouts/forms.less
@@ -1,4 +1,11 @@
 button,
+html [type="button"],
+[type="reset"],
+[type="submit"] {
+    cursor: pointer;
+}
+
+button,
 input,
 optgroup,
 select,


### PR DESCRIPTION
`cursor: pointer` was removed in a recent update to normalize.css. This commit restores the style for buttons and related form elements.