### PR TITLE
Fix the visual height of the button within .wdn-input-group-btn

### DIFF
--- a/wdn/templates_4.1/less/layouts/forms.less
+++ b/wdn/templates_4.1/less/layouts/forms.less
@@ -151,7 +151,7 @@ form {
 
             > * {
                 line-height: normal;
-                padding: 1.3em 1.333em;
+                padding: 1.64em 1.333em;
                 margin: 0;
                 border-radius: 0;
             }


### PR DESCRIPTION
Tested in Chrome, FF, Safari

Before:
<img width="890" alt="screen shot 2017-08-18 at 2 25 58 pm" src="https://user-images.githubusercontent.com/446357/29474421-447716f4-8421-11e7-9df8-cd3f4b3a6617.png">


After:
<img width="890" alt="screen shot 2017-08-18 at 2 25 41 pm" src="https://user-images.githubusercontent.com/446357/29474391-213f0b06-8421-11e7-9fbf-64fac076d800.png">
