### PR TITLE
update links to use https

### DIFF
--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -20,9 +20,9 @@
 				<li><a href="https://directory.unl.edu/" class="wdn-footer-list-item">Directory</a></li>
 				<li><a href="https://employment.unl.edu/" class="wdn-footer-list-item">Employment</a></li>
 				<li><a href="https://events.unl.edu/" class="wdn-footer-list-item">Events</a></li>
-				<li><a href="http://libraries.unl.edu/" class="wdn-footer-list-item">Libraries</a></li>
+				<li><a href="https://libraries.unl.edu/" class="wdn-footer-list-item">Libraries</a></li>
 				<li><a href="https://maps.unl.edu/" class="wdn-footer-list-item">Maps</a></li>
-				<li><a href="http://www.unl.edu/chancellor/" class="wdn-footer-list-item">Office of the Chancellor</a></li>
+				<li><a href="https://www.unl.edu/chancellor/" class="wdn-footer-list-item">Office of the Chancellor</a></li>
 				<li><a href="http://news.unl.edu/newsrooms/today/" class="wdn-footer-list-item">Nebraska Today</a></li>
 			</ul>
 		</div>
@@ -31,13 +31,13 @@
 		<div class="wdn-footer-module wdn-footer-policies">
 			<span role="heading">Policies</span>
 			<ul class="wdn-footer-list">
-				<li><a href="http://emergency.unl.edu/" class="wdn-footer-list-item">Emergency Planning and Preparedness</a></li>
-				<li><a href="http://www.unl.edu/equity/" class="wdn-footer-list-item">Institutional Equity and Compliance</a></li>
-				<li><a href="http://www.unl.edu/equity/notice-nondiscrimination" class="wdn-footer-list-item">Notice of Nondiscrimination</a></li>
-				<li><a href="http://its.unl.edu/unlprivacypolicy" class="wdn-footer-list-item">Privacy Policy</a></li>
-				<li><a href="http://heoa.unl.edu/" class="wdn-footer-list-item">Student Information Disclosures</a></li>
+				<li><a href="https://emergency.unl.edu/" class="wdn-footer-list-item">Emergency Planning and Preparedness</a></li>
+				<li><a href="https://www.unl.edu/equity/" class="wdn-footer-list-item">Institutional Equity and Compliance</a></li>
+				<li><a href="https://www.unl.edu/equity/notice-nondiscrimination" class="wdn-footer-list-item">Notice of Nondiscrimination</a></li>
+				<li><a href="https://its.unl.edu/unlprivacypolicy" class="wdn-footer-list-item">Privacy Policy</a></li>
+				<li><a href="https://heoa.unl.edu/" class="wdn-footer-list-item">Student Information Disclosures</a></li>
 			</ul>
-			<a href="http://www.unl.edu/tips-incident-reporting-system/" id="tips_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">TIPS Incident Reporting</span></a>
+			<a href="https://www.unl.edu/tips-incident-reporting-system/" id="tips_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">TIPS Incident Reporting</span></a>
 		</div>
 	</div>
 </div>
@@ -47,15 +47,15 @@
 			<div class="wdn-grid-set">
 				<div class="bp640-wdn-col-one-third">
     				<div id="nebraska-b1g-lockup">
-                        <a href="http://www.unl.edu/" id="footer_n_logo" class="wdn-footer-logo"><span class="wdn-text-hidden">University of Nebraska&ndash;Lincoln</span></a>
-                        <a href="http://www.unl.edu/about/academic-partnerships/" id="b1g_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">About the Big Ten Conference</span></a>
+                        <a href="https://www.unl.edu/" id="footer_n_logo" class="wdn-footer-logo"><span class="wdn-text-hidden">University of Nebraska&ndash;Lincoln</span></a>
+                        <a href="https://www.unl.edu/about/academic-partnerships/" id="b1g_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">About the Big Ten Conference</span></a>
                     </div>
 				</div>
 				<div class="bp640-wdn-col-two-thirds">
         			<div class="wdn-footer-text">
             			<div>
-        					<span class="wdn-wdn-qa">UNL web framework and quality assurance provided by the <a href="http://wdn.unl.edu/">Web&nbsp;Developer&nbsp;Network</a>&nbsp;&middot;&nbsp;<a href="https://webaudit.unl.edu/qa-test/">QA&nbsp;Test</a></span>
-        					<span class="wdn-copyright-phone">&copy; 2017 <a href="http://www.unl.edu/about/">University of Nebraska&ndash;Lincoln</a> &middot; <a href="tel:+14024727211">402-472-7211</a></span>
+        					<span class="wdn-wdn-qa">UNL web framework and quality assurance provided by the <a href="https://wdn.unl.edu/">Web&nbsp;Developer&nbsp;Network</a>&nbsp;&middot;&nbsp;<a href="https://webaudit.unl.edu/qa-test/">QA&nbsp;Test</a></span>
+        					<span class="wdn-copyright-phone">&copy; 2017 <a href="https://www.unl.edu/about/">University of Nebraska&ndash;Lincoln</a> &middot; <a href="tel:+14024727211">402-472-7211</a></span>
                         </div>
                         <a href="https://nebraska.edu/" id="unl_wordmark" class="wdn-footer-logo"><span class="wdn-text-hidden">University of Nebraska System</span></a>
         			</div>

--- a/wdn/templates_4.1/includes/logo.html
+++ b/wdn/templates_4.1/includes/logo.html
@@ -1,1 +1,1 @@
-<a href="http://www.unl.edu/" id="logo"><span class="wdn-text-hidden">UNL</span></a>
+<a href="https://www.unl.edu/" id="logo"><span class="wdn-text-hidden">UNL</span></a>

--- a/wdn/templates_4.1/scripts/legacy.js
+++ b/wdn/templates_4.1/scripts/legacy.js
@@ -28,11 +28,11 @@ define(['jquery', 'wdn', 'require'], function($, WDN, require) {
 		"windowsxp":  {
 			"enabled": window.navigator.userAgent.match(reXPAgent) && !WDN.getCookie(xpCookie),
 			"html": "Windows XP is no longer maintained by Microsoft or supported at UNL since April 8, 2014. You are strongly encouraged to upgrade.",
-			"url": "http://its.unl.edu/helpcenter/upgrade-windows-xp"
+			"url": "https://its.unl.edu/helpcenter/upgrade-windows-xp"
 		},
 		"oldie": {
 			"enabled": ie && ie < minIEVersion,
-			"html": "This page may not be displayed correctly in this browser. You are strongly encouraged to update. <a href=\"http://its.unl.edu/supported-technology-standards-end-life-software\">Read More</a>",
+			"html": "This page may not be displayed correctly in this browser. You are strongly encouraged to update. <a href=\"https://its.unl.edu/supported-technology-standards-end-life-software\">Read More</a>",
 			"url": "http://windows.microsoft.com/en-us/internet-explorer/download-ie"
 		}
 	};


### PR DESCRIPTION
Because the CMS was recently updated to force https, most of the links in the includes were 301ing. This updates those links.

There is also a link to http://www.unl.edu/ in the header, which is not in an include. That will be much harder to fix.