### PR TITLE
Search results markup & styling

### DIFF
--- a/wdn/templates_5.0/includes/global/search.html
+++ b/wdn/templates_5.0/includes/global/search.html
@@ -22,18 +22,19 @@
     </div>
   </form>
 
-  <div class="dcf-c-modal__overlay dcf-u-overlay-light" role="dialog" aria-hidden="true" aria-label="modal">
+  <div class="dcf-c-modal__overlay dcf-u-bg-overlay-light" role="dialog" aria-hidden="true" aria-label="modal">
     <div class="dcf-c-modal__content dcf-u-flex dcf-u-ai-flexend dcf-u-h100" role="document" tabindex="-1">
 
 
       <div class="dcf-c-search-results-wrapper dcf-u-overflow-y-scroll">
-        <div class="dcf-c-search-results dcf-u-pb6 dcf-u-sm3 unl-u-font-sans">
+        <div class="dcf-c-search-results dcf-u-pb10 dcf-u-sm3 unl-u-font-sans">
 
           <!-- Web -->
           <div class="dcf-c-search-results__web">
-            <h2 class="dcf-u-mb4 dcf-u-h6"><span class="dcf-u-uppercase dcf-u-ls1">Pages</span> <small class="dcf-u-pl2 dcf-u-sm2 dcf-u-regular dcf-u-ls0">3 results found</small></h2>
+            <h2 class="dcf-u-mb0 dcf-u-h6 dcf-u-uppercase dcf-u-ls1">Pages</h2>
 
-  <div id="unl_results" class="google-results" style="display: block;"><div id="___gcse_0"><div class="gsc-control-cse gsc-control-cse-en"><div class="gsc-control-wrapper-cse" dir="ltr" style="visibility: visible;"><div class="gsc-results-wrapper-nooverlay gsc-results-wrapper-visible"><div class="gsc-tabsAreaInvisible"><div class="gsc-tabHeader gsc-inline-block gsc-tabhActive"><span>University of Nebraska-Lincoln</span></div><span class="gs-spacer"> </span></div><div class="gsc-tabsAreaInvisible"></div><div class="gsc-above-wrapper-area"><table cellspacing="0" cellpadding="0" class="gsc-above-wrapper-area-container"><tbody><tr><td class="gsc-result-info-container"><div class="gsc-result-info" id="resInfo-0">About 160,000 results (0.40 seconds)</div></td></tr></tbody></table></div><div class="gsc-adBlockNoHeight" style="height: 0px;"></div><div class="gsc-wrapper"><div class="gsc-adBlockNoHeight" style="height: 0px; font-weight: normal; text-align: center;"><iframe frameborder="0" marginwidth="0" marginheight="0" allowtransparency="true" scrolling="no" width="100%" name="{&quot;name&quot;:&quot;master-1&quot;,&quot;master-1&quot;:{&quot;linkTarget&quot;:&quot;_top&quot;,&quot;lines&quot;:3,&quot;fontSizeTitle&quot;:&quot;16px&quot;,&quot;fontSizeDescription&quot;:&quot;13px&quot;,&quot;fontSizeDomainLink&quot;:&quot;13px&quot;,&quot;position&quot;:&quot;top&quot;,&quot;cseGoogleHosting&quot;:&quot;partner&quot;,&quot;adIconLocation&quot;:&quot;ad-left&quot;,&quot;type&quot;:&quot;ads&quot;,&quot;hl&quot;:&quot;en&quot;,&quot;columns&quot;:1,&quot;horizontalAlignment&quot;:&quot;left&quot;,&quot;resultsPageQueryParam&quot;:&quot;query&quot;}}" id="master-1" src="https://cse.google.com/cse_v2/ads?q=smith&amp;r=m&amp;cx=015236299699564929946%3Ank1siew10ie&amp;client=google-coop&amp;hl=en&amp;type=0&amp;oe=UTF-8&amp;ie=UTF-8&amp;fexp=20606%2C7000810&amp;format=p4&amp;ad=p4&amp;nocache=1461511976613824&amp;num=0&amp;output=uds_ads_only&amp;source=gcsc&amp;v=3&amp;adext=as1%2Csr1&amp;bsl=10&amp;u_his=5&amp;u_tz=-360&amp;dt=1511976613825&amp;u_w=1920&amp;u_h=1080&amp;biw=-12245933&amp;bih=-12245933&amp;isw=630&amp;ish=570&amp;psw=630&amp;psh=0&amp;frm=2&amp;uio=uv3st16sd13sv13lhsl1sr1-&amp;jsv=50136&amp;rurl=https%3A%2F%2Fsearch.unl.edu%2F%3Fembed%3D1%26q%3Dsmith&amp;referer=https%3A%2F%2Fwww.unl.edu%2F#master-1" style="visibility: hidden; height: 0px;"></iframe></div><div class="gsc-resultsbox-visible"><div class="gsc-resultsRoot gsc-tabData gsc-tabdActive"><table cellspacing="0" cellpadding="0" class="gsc-resultsHeader"><tbody><tr><td class="gsc-twiddleRegionCell gsc-twiddle-opened"><div class="gsc-twiddle"><div class="gsc-title">Web</div></div><div class="gsc-stats">(10)</div><div class="gsc-results-selector gsc-all-results-active"><div class="gsc-result-selector gsc-one-result" title="show one result">&nbsp;</div><div class="gsc-result-selector gsc-more-results" title="show more results">&nbsp;</div><div class="gsc-result-selector gsc-all-results" title="show all results">&nbsp;</div></div></td><td class="gsc-configLabelCell"></td></tr></tbody></table><div class="gsc-results gsc-webResult" style="display: block;"><div class="gcsc-branding"><span class="gcsc-branding-text">powered by</span><a href="http://cse.google.com/cse/?hl=en" target="_BLANK" class="gcsc-branding-clickable"><img src="https://www.google.com/cse/static/images/1x/googlelogo_grey_46x15dp.png" class="gcsc-branding-img-noclear" srcset="https://www.google.com/cse/static/images/2x/googlelogo_grey_46x15dp.png 2x"></a><span class="gcsc-branding-text gcsc-branding-text-name">Custom Search</span></div><div class="gsc-webResult gsc-result"><div class="gs-webResult gs-result"><div class="gsc-thumbnail-inside"><div class="gs-title"><a class="gs-title" href="https://housing.unl.edu/smith-hall" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=https://housing.unl.edu/smith-hall&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggEMAA&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2J2XbWrXLoAJk8Q05rxUXI" data-ctorig="https://housing.unl.edu/smith-hall"><b>Smith</b> Hall | University Housing | University of Nebraska–Lincoln</a></div></div><div class="gsc-url-top"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">housing.unl.edu</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">https://housing.unl.edu/<b>smith</b>-hall</div></div><table class="gsc-table-result"><tbody><tr><td class="gsc-table-cell-thumbnail gsc-thumbnail" style=""><div class="gs-image-box gs-web-image-box gs-web-image-box-landscape"><a class="gs-image" href="https://housing.unl.edu/smith-hall" target="_blank" data-cturl="https://www.google.com/url?q=https://housing.unl.edu/smith-hall&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggEMAA&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2J2XbWrXLoAJk8Q05rxUXI" data-ctorig="https://housing.unl.edu/smith-hall"><img class="gs-image" onload="if (this.parentNode &amp;&amp; this.parentNode.parentNode &amp;&amp; this.parentNode.parentNode.parentNode) { this.parentNode.parentNode.parentNode.style.display = ''; this.parentNode.parentNode.className = 'gs-image-box gs-web-image-box gs-web-image-box-landscape'; } " src="https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcQ6jEQCrRth8yAf3LC1y7L18rW-Ww-aA3X51D406In23Ig1GvAAfPU8610"></a></div></td><td onclick="if (this.className == 'gsc-table-cell-snippet-close gsc-collapsable') { this.className = 'gsc-table-cell-snippet-open gsc-collapsable'; } else if (this.className == 'gsc-table-cell-snippet-open gsc-collapsable') { this.className = 'gsc-table-cell-snippet-close gsc-collapsable'; };" class="gsc-table-cell-snippet-close"><div class="gs-title gsc-table-cell-thumbnail gsc-thumbnail-left"><a class="gs-title" href="https://housing.unl.edu/smith-hall" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=https://housing.unl.edu/smith-hall&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggEMAA&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2J2XbWrXLoAJk8Q05rxUXI" data-ctorig="https://housing.unl.edu/smith-hall"><b>Smith</b> Hall | University Housing | University of Nebraska–Lincoln</a></div><div><span></span></div><div class="gs-bidi-start-align gs-snippet" dir="ltr"><b>Smith</b> is a coed hall located at the north end of City Campus, houses several First
+            <div class="unl-google-results" id="unl_results" style="display: block;">
+              <div id="___gcse_0"><div class="gsc-control-cse gsc-control-cse-en"><div class="gsc-control-wrapper-cse" dir="ltr" style="visibility: visible;"><div class="gsc-results-wrapper-nooverlay gsc-results-wrapper-visible"><div class="gsc-tabsAreaInvisible"><div class="gsc-tabHeader gsc-inline-block gsc-tabhActive"><span>University of Nebraska-Lincoln</span></div><span class="gs-spacer"> </span></div><div class="gsc-tabsAreaInvisible"></div><div class="gsc-above-wrapper-area"><table cellspacing="0" cellpadding="0" class="gsc-above-wrapper-area-container"><tbody><tr><td class="gsc-result-info-container"><div class="gsc-result-info" id="resInfo-0">About 160,000 results (0.40 seconds)</div></td></tr></tbody></table></div><div class="gsc-adBlockNoHeight" style="height: 0px;"></div><div class="gsc-wrapper"><div class="gsc-adBlockNoHeight" style="height: 0px; font-weight: normal; text-align: center;"><iframe frameborder="0" marginwidth="0" marginheight="0" allowtransparency="true" scrolling="no" width="100%" name="{&quot;name&quot;:&quot;master-1&quot;,&quot;master-1&quot;:{&quot;linkTarget&quot;:&quot;_top&quot;,&quot;lines&quot;:3,&quot;fontSizeTitle&quot;:&quot;16px&quot;,&quot;fontSizeDescription&quot;:&quot;13px&quot;,&quot;fontSizeDomainLink&quot;:&quot;13px&quot;,&quot;position&quot;:&quot;top&quot;,&quot;cseGoogleHosting&quot;:&quot;partner&quot;,&quot;adIconLocation&quot;:&quot;ad-left&quot;,&quot;type&quot;:&quot;ads&quot;,&quot;hl&quot;:&quot;en&quot;,&quot;columns&quot;:1,&quot;horizontalAlignment&quot;:&quot;left&quot;,&quot;resultsPageQueryParam&quot;:&quot;query&quot;}}" id="master-1" src="https://cse.google.com/cse_v2/ads?q=smith&amp;r=m&amp;cx=015236299699564929946%3Ank1siew10ie&amp;client=google-coop&amp;hl=en&amp;type=0&amp;oe=UTF-8&amp;ie=UTF-8&amp;fexp=20606%2C7000810&amp;format=p4&amp;ad=p4&amp;nocache=1461511976613824&amp;num=0&amp;output=uds_ads_only&amp;source=gcsc&amp;v=3&amp;adext=as1%2Csr1&amp;bsl=10&amp;u_his=5&amp;u_tz=-360&amp;dt=1511976613825&amp;u_w=1920&amp;u_h=1080&amp;biw=-12245933&amp;bih=-12245933&amp;isw=630&amp;ish=570&amp;psw=630&amp;psh=0&amp;frm=2&amp;uio=uv3st16sd13sv13lhsl1sr1-&amp;jsv=50136&amp;rurl=https%3A%2F%2Fsearch.unl.edu%2F%3Fembed%3D1%26q%3Dsmith&amp;referer=https%3A%2F%2Fwww.unl.edu%2F#master-1" style="visibility: hidden; height: 0px;"></iframe></div><div class="gsc-resultsbox-visible"><div class="gsc-resultsRoot gsc-tabData gsc-tabdActive"><table cellspacing="0" cellpadding="0" class="gsc-resultsHeader"><tbody><tr><td class="gsc-twiddleRegionCell gsc-twiddle-opened"><div class="gsc-twiddle"><div class="gsc-title">Web</div></div><div class="gsc-stats">(10)</div><div class="gsc-results-selector gsc-all-results-active"><div class="gsc-result-selector gsc-one-result" title="show one result">&nbsp;</div><div class="gsc-result-selector gsc-more-results" title="show more results">&nbsp;</div><div class="gsc-result-selector gsc-all-results" title="show all results">&nbsp;</div></div></td><td class="gsc-configLabelCell"></td></tr></tbody></table><div class="gsc-results gsc-webResult" style="display: block;"><div class="gcsc-branding"><span class="gcsc-branding-text">powered by</span><a href="http://cse.google.com/cse/?hl=en" target="_BLANK" class="gcsc-branding-clickable"><img src="https://www.google.com/cse/static/images/1x/googlelogo_grey_46x15dp.png" class="gcsc-branding-img-noclear" srcset="https://www.google.com/cse/static/images/2x/googlelogo_grey_46x15dp.png 2x"></a><span class="gcsc-branding-text gcsc-branding-text-name">Custom Search</span></div><div class="gsc-webResult gsc-result"><div class="gs-webResult gs-result"><div class="gsc-thumbnail-inside"><div class="gs-title"><a class="gs-title" href="https://housing.unl.edu/smith-hall" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=https://housing.unl.edu/smith-hall&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggEMAA&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2J2XbWrXLoAJk8Q05rxUXI" data-ctorig="https://housing.unl.edu/smith-hall"><b>Smith</b> Hall | University Housing | University of Nebraska–Lincoln</a></div></div><div class="gsc-url-top"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">housing.unl.edu</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">https://housing.unl.edu/<b>smith</b>-hall</div></div><table class="gsc-table-result"><tbody><tr><td class="gsc-table-cell-thumbnail gsc-thumbnail" style=""><div class="gs-image-box gs-web-image-box gs-web-image-box-landscape"><a class="gs-image" href="https://housing.unl.edu/smith-hall" target="_blank" data-cturl="https://www.google.com/url?q=https://housing.unl.edu/smith-hall&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggEMAA&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2J2XbWrXLoAJk8Q05rxUXI" data-ctorig="https://housing.unl.edu/smith-hall"><img class="gs-image" onload="if (this.parentNode &amp;&amp; this.parentNode.parentNode &amp;&amp; this.parentNode.parentNode.parentNode) { this.parentNode.parentNode.parentNode.style.display = ''; this.parentNode.parentNode.className = 'gs-image-box gs-web-image-box gs-web-image-box-landscape'; } " src="https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcQ6jEQCrRth8yAf3LC1y7L18rW-Ww-aA3X51D406In23Ig1GvAAfPU8610"></a></div></td><td onclick="if (this.className == 'gsc-table-cell-snippet-close gsc-collapsable') { this.className = 'gsc-table-cell-snippet-open gsc-collapsable'; } else if (this.className == 'gsc-table-cell-snippet-open gsc-collapsable') { this.className = 'gsc-table-cell-snippet-close gsc-collapsable'; };" class="gsc-table-cell-snippet-close"><div class="gs-title gsc-table-cell-thumbnail gsc-thumbnail-left"><a class="gs-title" href="https://housing.unl.edu/smith-hall" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=https://housing.unl.edu/smith-hall&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggEMAA&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2J2XbWrXLoAJk8Q05rxUXI" data-ctorig="https://housing.unl.edu/smith-hall"><b>Smith</b> Hall | University Housing | University of Nebraska–Lincoln</a></div><div><span></span></div><div class="gs-bidi-start-align gs-snippet" dir="ltr"><b>Smith</b> is a coed hall located at the north end of City Campus, houses several First
   Year Learning Communities and operates a 24-hour residence hall desk.</div><div class="gsc-url-bottom"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">housing.unl.edu</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">https://housing.unl.edu/<b>smith</b>-hall</div></div><div class="gs-richsnippet-box" style="display: none;"></div><div class="gs-per-result-labels" url="https://housing.unl.edu/smith-hall"></div></td></tr></tbody></table></div><div class="gs-watermark"><a href="http://code.google.com/apis/ajaxsearch/faq.html" class="gs-watermark" target="_blank">clipped from Google - 11/2017</a></div></div><div class="gsc-expansionArea"><div class="gsc-webResult gsc-result"><div class="gs-webResult gs-result"><div class="gsc-thumbnail-inside"><div class="gs-title"><a class="gs-title" href="http://www.huskers.com/ViewArticle.dbml?ATCLID=208592560" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=http://www.huskers.com/ViewArticle.dbml%3FATCLID%3D208592560&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggGMAE&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw1NRAj3vZBgwNVOvx_ko_os" data-ctorig="http://www.huskers.com/ViewArticle.dbml?ATCLID=208592560">Pat <b>Smith</b> Bio - Huskers.com - Nebraska Athletics Official Web Site</a></div></div><div class="gsc-url-top"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">www.huskers.com</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">www.huskers.com/ViewArticle.dbml?ATCLID=208592560</div></div><table class="gsc-table-result"><tbody><tr><td class="gsc-table-cell-thumbnail gsc-thumbnail" style=""><div class="gs-image-box gs-web-image-box gs-web-image-box-portrait"><a class="gs-image" href="http://www.huskers.com/ViewArticle.dbml?ATCLID=208592560" target="_blank" data-cturl="https://www.google.com/url?q=http://www.huskers.com/ViewArticle.dbml%3FATCLID%3D208592560&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggGMAE&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw1NRAj3vZBgwNVOvx_ko_os" data-ctorig="http://www.huskers.com/ViewArticle.dbml?ATCLID=208592560"><img class="gs-image" onload="if (this.parentNode &amp;&amp; this.parentNode.parentNode &amp;&amp; this.parentNode.parentNode.parentNode) { this.parentNode.parentNode.parentNode.style.display = ''; this.parentNode.parentNode.className = 'gs-image-box gs-web-image-box gs-web-image-box-portrait'; } " src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTxPxgGcAt_QSgf84Y1XfBno_pM4RAVXvr_TXaBYcc3CtPiFp2IAaRYCuLb"></a></div></td><td onclick="if (this.className == 'gsc-table-cell-snippet-close gsc-collapsable') { this.className = 'gsc-table-cell-snippet-open gsc-collapsable'; } else if (this.className == 'gsc-table-cell-snippet-open gsc-collapsable') { this.className = 'gsc-table-cell-snippet-close gsc-collapsable'; };" class="gsc-table-cell-snippet-close"><div class="gs-title gsc-table-cell-thumbnail gsc-thumbnail-left"><a class="gs-title" href="http://www.huskers.com/ViewArticle.dbml?ATCLID=208592560" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=http://www.huskers.com/ViewArticle.dbml%3FATCLID%3D208592560&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggGMAE&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw1NRAj3vZBgwNVOvx_ko_os" data-ctorig="http://www.huskers.com/ViewArticle.dbml?ATCLID=208592560">Pat <b>Smith</b> Bio - Huskers.com - Nebraska Athletics Official Web Site</a></div><div><span></span></div><div class="gs-bidi-start-align gs-snippet" dir="ltr">Place-kicker Pat <b>Smith</b> joined the Nebraska program in the summer of 2013, and
   made a big contribution in his only season in a Husker uniform. <b>Smith</b> came to&nbsp;...</div><div class="gsc-url-bottom"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">www.huskers.com</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">www.huskers.com/ViewArticle.dbml?ATCLID=208592560</div></div><div class="gs-richsnippet-box" style="display: none;"></div><div class="gs-per-result-labels" url="http://www.huskers.com/ViewArticle.dbml?ATCLID=208592560"></div></td></tr></tbody></table></div><div class="gs-watermark"><a href="http://code.google.com/apis/ajaxsearch/faq.html" class="gs-watermark" target="_blank">clipped from Google - 11/2017</a></div></div><div class="gsc-webResult gsc-result"><div class="gs-webResult gs-result"><div class="gsc-thumbnail-inside"><div class="gs-title"><a class="gs-title" href="https://arts.unl.edu/theatre-and-film/faculty/harris-smith" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=https://arts.unl.edu/theatre-and-film/faculty/harris-smith&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggIMAI&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw0ZIdwSUmzb_qFNhcT4u3Gn" data-ctorig="https://arts.unl.edu/theatre-and-film/faculty/harris-smith">Harris <b>Smith</b> | Hixson-Lied College of Fine and Performing Arts ...</a></div></div><div class="gsc-url-top"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">arts.unl.edu</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">https://arts.unl.edu/theatre-and-film/faculty/harris-<b>smith</b></div></div><table class="gsc-table-result"><tbody><tr><td class="gsc-table-cell-thumbnail gsc-thumbnail" style=""><div class="gs-image-box gs-web-image-box gs-web-image-box-portrait"><a class="gs-image" href="https://arts.unl.edu/theatre-and-film/faculty/harris-smith" target="_blank" data-cturl="https://www.google.com/url?q=https://arts.unl.edu/theatre-and-film/faculty/harris-smith&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggIMAI&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw0ZIdwSUmzb_qFNhcT4u3Gn" data-ctorig="https://arts.unl.edu/theatre-and-film/faculty/harris-smith"><img class="gs-image" onload="if (this.parentNode &amp;&amp; this.parentNode.parentNode &amp;&amp; this.parentNode.parentNode.parentNode) { this.parentNode.parentNode.parentNode.style.display = ''; this.parentNode.parentNode.className = 'gs-image-box gs-web-image-box gs-web-image-box-portrait'; } " src="https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcQtj8kYnoi76AAEJER3WizZLE58Qq3yD4vyJQGdM8IqyJ_MlKHB1JtKMv4"></a></div></td><td onclick="if (this.className == 'gsc-table-cell-snippet-close gsc-collapsable') { this.className = 'gsc-table-cell-snippet-open gsc-collapsable'; } else if (this.className == 'gsc-table-cell-snippet-open gsc-collapsable') { this.className = 'gsc-table-cell-snippet-close gsc-collapsable'; };" class="gsc-table-cell-snippet-close"><div class="gs-title gsc-table-cell-thumbnail gsc-thumbnail-left"><a class="gs-title" href="https://arts.unl.edu/theatre-and-film/faculty/harris-smith" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=https://arts.unl.edu/theatre-and-film/faculty/harris-smith&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggIMAI&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw0ZIdwSUmzb_qFNhcT4u3Gn" data-ctorig="https://arts.unl.edu/theatre-and-film/faculty/harris-smith">Harris <b>Smith</b> | Hixson-Lied College of Fine and Performing Arts ...</a></div><div><span><span><span><span class="gsc-role"> Director</span><span class="gsc-org"><span> @University of Nebraska–Lincoln</span></span><span class="gsc-location"><span> - </span><span> Lincoln Nebraska</span></span></span></span></span></div><div class="gs-bidi-start-align gs-snippet" dir="ltr">Harris <b>Smith</b> is the Director of the Johnny Carson School of Theatre &amp; Film at the
   University of Nebraska-Lincoln as well as the Head of the Professional Actor&nbsp;...</div><div class="gsc-url-bottom"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">arts.unl.edu</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">https://arts.unl.edu/theatre-and-film/faculty/harris-<b>smith</b></div></div><div class="gs-richsnippet-box" style="display: none;"></div><div class="gs-per-result-labels" url="https://arts.unl.edu/theatre-and-film/faculty/harris-smith"></div></td></tr></tbody></table></div><div class="gs-watermark"><a href="http://code.google.com/apis/ajaxsearch/faq.html" class="gs-watermark" target="_blank">clipped from Google - 11/2017</a></div></div><div class="gsc-webResult gsc-result"><div class="gs-webResult gs-result"><div class="gsc-thumbnail-inside"><div class="gs-title"><a class="gs-title" href="http://www.huskers.com/ViewArticle.dbml?DB_OEM_ID=100&amp;ATCLID=210739852" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=http://www.huskers.com/ViewArticle.dbml%3FDB_OEM_ID%3D100%26ATCLID%3D210739852&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggKMAM&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2_aFUHH69Ai9N4eDJ_8fBT" data-ctorig="http://www.huskers.com/ViewArticle.dbml?DB_OEM_ID=100&amp;ATCLID=210739852">Nick <b>Smith</b> Bio - Huskers.com - Nebraska Athletics Official Web Site</a></div></div><div class="gsc-url-top"><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-short" dir="ltr">www.huskers.com</div><div class="gs-bidi-start-align gs-visibleUrl gs-visibleUrl-long" dir="ltr" style="word-break:break-all;">www.huskers.com/ViewArticle.dbml?DB_OEM_ID=100...</div></div><table class="gsc-table-result"><tbody><tr><td class="gsc-table-cell-thumbnail gsc-thumbnail" style=""><div class="gs-image-box gs-web-image-box gs-web-image-box-portrait"><a class="gs-image" href="http://www.huskers.com/ViewArticle.dbml?DB_OEM_ID=100&amp;ATCLID=210739852" target="_blank" data-cturl="https://www.google.com/url?q=http://www.huskers.com/ViewArticle.dbml%3FDB_OEM_ID%3D100%26ATCLID%3D210739852&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggKMAM&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2_aFUHH69Ai9N4eDJ_8fBT" data-ctorig="http://www.huskers.com/ViewArticle.dbml?DB_OEM_ID=100&amp;ATCLID=210739852"><img class="gs-image" onload="if (this.parentNode &amp;&amp; this.parentNode.parentNode &amp;&amp; this.parentNode.parentNode.parentNode) { this.parentNode.parentNode.parentNode.style.display = ''; this.parentNode.parentNode.className = 'gs-image-box gs-web-image-box gs-web-image-box-portrait'; } " src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTxPxgGcAt_QSgf84Y1XfBno_pM4RAVXvr_TXaBYcc3CtPiFp2IAaRYCuLb"></a></div></td><td onclick="if (this.className == 'gsc-table-cell-snippet-close gsc-collapsable') { this.className = 'gsc-table-cell-snippet-open gsc-collapsable'; } else if (this.className == 'gsc-table-cell-snippet-open gsc-collapsable') { this.className = 'gsc-table-cell-snippet-close gsc-collapsable'; };" class="gsc-table-cell-snippet-close"><div class="gs-title gsc-table-cell-thumbnail gsc-thumbnail-left"><a class="gs-title" href="http://www.huskers.com/ViewArticle.dbml?DB_OEM_ID=100&amp;ATCLID=210739852" target="_blank" dir="ltr" data-cturl="https://www.google.com/url?q=http://www.huskers.com/ViewArticle.dbml%3FDB_OEM_ID%3D100%26ATCLID%3D210739852&amp;sa=U&amp;ved=0ahUKEwjE4Onnp-TXAhUs9YMKHYiFCagQFggKMAM&amp;client=internal-uds-cse&amp;cx=015236299699564929946:nk1siew10ie&amp;usg=AOvVaw2_aFUHH69Ai9N4eDJ_8fBT" data-ctorig="http://www.huskers.com/ViewArticle.dbml?DB_OEM_ID=100&amp;ATCLID=210739852">Nick <b>Smith</b> Bio - Huskers.com - Nebraska Athletics Official Web Site</a></div><div><span></span></div><div class="gs-bidi-start-align gs-snippet" dir="ltr">Nick <b>Smith</b> is in his second season on the Nebraska coaching staff working as a
@@ -53,209 +54,196 @@
 
             <!-- Affiliates -->
             <div class="dcf-c-search-results__affiliates">
-              <h2 class="dcf-u-mb4 dcf-u-h6"><span class="dcf-u-uppercase dcf-u-ls1">Affiliate</span> <small class="dcf-u-pl2 dcf-u-sm2 dcf-u-regular dcf-u-ls0">7 results found</small></h2>
-              <ul class="dcf-c-list-unstyled pfResult">
-                <li class="dcf-u-mb4 ppl_Sresult affiliate" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
+              <h2 class="dcf-u-mb0 dcf-u-h6 dcf-u-uppercase dcf-u-ls1">Affiliates</h2>
+              <div class="dcf-u-mb7">7 results found</div>
+              <ul class="dcf-c-list-unstyled dcf-u-mb0 [pfResult]">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult affiliate]" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Research Asst Professor</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Museum</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Research Asst Professor</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Museum</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024722664">402-472-2664</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2664</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722664" itemprop="telephone">402-472-2664</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2664</small>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 ppl_Sresult affiliate" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
-                    </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Installer</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">Procurement Services</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024722126">402-472-2126</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2126</small>
-                      </div>
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
                   </div>
                 </li>
-                <li class="dcf-u-mb4 ppl_Sresult affiliate" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult affiliate]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Radio Traffic/Continuity</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Television</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Installer</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Procurement Services</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024729333">402-472-9333</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-9333</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722126" itemprop="telephone">402-472-2126</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2126</small>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 ppl_Sresult affiliate" tabindex="0" data-href="https://directory.unl.edu/people/jsmith106" data-uid="jsmith106">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith106?s=small" alt="Avatar for Jesse Smith">
-                    </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith106" onclick="return pf_getUID('jsmith106');" aria-label="Show more information about Smith,&nbsp;Jesse">Smith,&nbsp;Jesse</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Windstream Employee</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">Office of Information Technology Services</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024722014">402-472-2014</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2014</small>
-                      </div>
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
                   </div>
                 </li>
-                <li class="dcf-u-mb4 ppl_Sresult affiliate" tabindex="0" data-href="https://directory.unl.edu/people/rsmith53" data-uid="rsmith53">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith53?s=small" alt="Avatar for Ryan Smith">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult affiliate]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/rsmith53" onclick="return pf_getUID('rsmith53');" aria-label="Show more information about Smith,&nbsp;Ryan">Smith,&nbsp;Ryan</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Affiliate</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">NE College of Technical Agriculture</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Radio Traffic/Continuity</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Television</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024720316">402-472-0316</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-0316</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024729333" itemprop="telephone">402-472-9333</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-9333</small>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 ppl_Sresult affiliate" tabindex="0" data-href="https://directory.unl.edu/people/ssmith121" data-uid="ssmith121">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith121?s=small" alt="Avatar for Stephen Smith">
-                    </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/ssmith121" onclick="return pf_getUID('ssmith121');" aria-label="Show more information about Smith,&nbsp;Stephen">Smith,&nbsp;Stephen</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Architect-Kenneth Hahn</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">FM&amp;P Facilities Plan &amp; Construction</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024723131">402-472-3131</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-3131</small>
-                      </div>
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
                   </div>
                 </li>
-                <li class="dcf-u-mb4 ppl_Sresult affiliate" tabindex="0" data-href="https://directory.unl.edu/people/wsmith11" data-uid="wsmith11">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/wsmith11?s=small" alt="Avatar for William Smith">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult affiliate]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith106" data-uid="jsmith106" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith106" onclick="return pf_getUID('jsmith106');" aria-label="Show more information about Smith,&nbsp;Jesse">Smith,&nbsp;Jesse</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/wsmith11" onclick="return pf_getUID('wsmith11');" aria-label="Show more information about Smith,&nbsp;William">Smith,&nbsp;William</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Affiliate</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">Entomology</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Windstream Employee</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Office of Information Technology Services</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024722123">402-472-2123</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2123</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2014</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2014</small>
                     </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith106?s=small" alt="Avatar for Jesse Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult affiliate]" tabindex="0" data-href="https://directory.unl.edu/people/rsmith53" data-uid="rsmith53" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/rsmith53" onclick="return pf_getUID('rsmith53');" aria-label="Show more information about Smith,&nbsp;Ryan">Smith,&nbsp;Ryan</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">NE College of Technical Agriculture</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-0316</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-0316</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/rsmith53?s=small" alt="Avatar for Ryan Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult affiliate]" tabindex="0" data-href="https://directory.unl.edu/people/ssmith121" data-uid="ssmith121" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/ssmith121" onclick="return pf_getUID('ssmith121');" aria-label="Show more information about Smith,&nbsp;Stephen">Smith,&nbsp;Stephen</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Architect-Kenneth Hahn</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">FM&amp;P Facilities Plan &amp; Construction</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-3131</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-3131</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/ssmith121?s=small" alt="Avatar for Stephen Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult affiliate]" tabindex="0" data-href="https://directory.unl.edu/people/wsmith11" data-uid="wsmith11" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/wsmith11" onclick="return pf_getUID('wsmith11');" aria-label="Show more information about Smith,&nbsp;William">Smith,&nbsp;William</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Entomology</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2123</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2123</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/wsmith11?s=small" alt="Avatar for William Smith">
                   </div>
                 </li>
               </ul>
@@ -263,93 +251,196 @@
 
             <!-- Faculty -->
             <div class="dcf-c-search-results__faculty">
-              <h2 class="dcf-u-mb4 dcf-u-h6"><span class="dcf-u-uppercase dcf-u-ls1">Faculty</span> <small class="dcf-u-pl2 dcf-u-sm2 dcf-u-regular dcf-u-ls0">29 results found</small></h2>
-              <ul class="dcf-c-list-unstyled pfResult">
-                <li class="dcf-u-mb4 ppl_Sresult faculty" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
+              <h2 class="dcf-u-mb0 dcf-u-h6 dcf-u-uppercase dcf-u-ls1">Faculty</h2>
+              <div class="dcf-u-mb7">29 results found</div>
+              <ul class="dcf-c-list-unstyled dcf-u-mb0 [pfResult]">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult faculty]" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Research Asst Professor</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Museum</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Research Asst Professor</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Museum</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024722664">402-472-2664</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2664</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722664" itemprop="telephone">402-472-2664</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2664</small>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 ppl_Sresult faculty" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
-                    </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Installer</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">Procurement Services</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024722126">402-472-2126</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2126</small>
-                      </div>
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
                   </div>
                 </li>
-                <li class="dcf-u-mb4 ppl_Sresult faculty" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult faculty]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Radio Traffic/Continuity</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Television</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Installer</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Procurement Services</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024729333">402-472-9333</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-9333</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722126" itemprop="telephone">402-472-2126</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2126</small>
                     </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult faculty]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Radio Traffic/Continuity</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Television</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024729333" itemprop="telephone">402-472-9333</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-9333</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult faculty]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith106" data-uid="jsmith106" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith106" onclick="return pf_getUID('jsmith106');" aria-label="Show more information about Smith,&nbsp;Jesse">Smith,&nbsp;Jesse</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Windstream Employee</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Office of Information Technology Services</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2014</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2014</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith106?s=small" alt="Avatar for Jesse Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult faculty]" tabindex="0" data-href="https://directory.unl.edu/people/rsmith53" data-uid="rsmith53" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/rsmith53" onclick="return pf_getUID('rsmith53');" aria-label="Show more information about Smith,&nbsp;Ryan">Smith,&nbsp;Ryan</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">NE College of Technical Agriculture</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-0316</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-0316</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/rsmith53?s=small" alt="Avatar for Ryan Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult faculty]" tabindex="0" data-href="https://directory.unl.edu/people/ssmith121" data-uid="ssmith121" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/ssmith121" onclick="return pf_getUID('ssmith121');" aria-label="Show more information about Smith,&nbsp;Stephen">Smith,&nbsp;Stephen</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Architect-Kenneth Hahn</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">FM&amp;P Facilities Plan &amp; Construction</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-3131</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-3131</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/ssmith121?s=small" alt="Avatar for Stephen Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult faculty]" tabindex="0" data-href="https://directory.unl.edu/people/wsmith11" data-uid="wsmith11" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/wsmith11" onclick="return pf_getUID('wsmith11');" aria-label="Show more information about Smith,&nbsp;William">Smith,&nbsp;William</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Entomology</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2123</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2123</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/wsmith11?s=small" alt="Avatar for William Smith">
                   </div>
                 </li>
               </ul>
@@ -357,93 +448,196 @@
 
             <!-- Staff -->
             <div class="dcf-c-search-results__staff">
-              <h2 class="dcf-u-mb4 dcf-u-h6"><span class="dcf-u-uppercase dcf-u-ls1">Staff</span> <small class="dcf-u-pl2 dcf-u-sm2 dcf-u-regular dcf-u-ls0">29 results found</small></h2>
-              <ul class="dcf-c-list-unstyled pfResult">
-                <li class="dcf-u-mb4 ppl_Sresult staff" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
+              <h2 class="dcf-u-mb0 dcf-u-h6 dcf-u-uppercase dcf-u-ls1">Staff</h2>
+              <div class="dcf-u-mb7">29 results found</div>
+              <ul class="dcf-c-list-unstyled dcf-u-mb0 pfResult">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult staff]" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Research Asst Professor</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Museum</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Research Asst Professor</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Museum</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024722664">402-472-2664</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2664</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722664" itemprop="telephone">402-472-2664</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2664</small>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 ppl_Sresult staff" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
-                    </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Installer</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">Procurement Services</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024722126">402-472-2126</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2126</small>
-                      </div>
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
                   </div>
                 </li>
-                <li class="dcf-u-mb4 ppl_Sresult staff" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult staff]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Radio Traffic/Continuity</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Television</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Installer</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Procurement Services</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024729333">402-472-9333</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-9333</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722126" itemprop="telephone">402-472-2126</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2126</small>
                     </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult staff]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Radio Traffic/Continuity</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Television</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024729333" itemprop="telephone">402-472-9333</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-9333</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult staff]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith106" data-uid="jsmith106" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith106" onclick="return pf_getUID('jsmith106');" aria-label="Show more information about Smith,&nbsp;Jesse">Smith,&nbsp;Jesse</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Windstream Employee</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Office of Information Technology Services</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2014</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2014</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith106?s=small" alt="Avatar for Jesse Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult staff]" tabindex="0" data-href="https://directory.unl.edu/people/rsmith53" data-uid="rsmith53" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/rsmith53" onclick="return pf_getUID('rsmith53');" aria-label="Show more information about Smith,&nbsp;Ryan">Smith,&nbsp;Ryan</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">NE College of Technical Agriculture</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-0316</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-0316</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/rsmith53?s=small" alt="Avatar for Ryan Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult staff]" tabindex="0" data-href="https://directory.unl.edu/people/ssmith121" data-uid="ssmith121" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/ssmith121" onclick="return pf_getUID('ssmith121');" aria-label="Show more information about Smith,&nbsp;Stephen">Smith,&nbsp;Stephen</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Architect-Kenneth Hahn</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">FM&amp;P Facilities Plan &amp; Construction</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-3131</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-3131</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/ssmith121?s=small" alt="Avatar for Stephen Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult staff]" tabindex="0" data-href="https://directory.unl.edu/people/wsmith11" data-uid="wsmith11" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/wsmith11" onclick="return pf_getUID('wsmith11');" aria-label="Show more information about Smith,&nbsp;William">Smith,&nbsp;William</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Entomology</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2123</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2123</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/wsmith11?s=small" alt="Avatar for William Smith">
                   </div>
                 </li>
               </ul>
@@ -451,93 +645,196 @@
 
             <!-- Students -->
             <div class="dcf-c-search-results__students">
-              <h2 class="dcf-u-mb4 dcf-u-h6"><span class="dcf-u-uppercase dcf-u-ls1">Students</span> <small class="dcf-u-pl2 dcf-u-sm2 dcf-u-regular dcf-u-ls0">178 results found</small></h2>
-              <ul class="dcf-c-list-unstyled pfResult">
-                <li class="dcf-u-mb4 ppl_Sresult student" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
+              <h2 class="dcf-u-mb0 dcf-u-h6 dcf-u-uppercase dcf-u-ls1">Students</h2>
+              <div class="dcf-u-mb7">178 results found</div>
+              <ul class="dcf-c-list-unstyled dcf-u-mb0 pfResult">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult student]" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Research Asst Professor</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Museum</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Research Asst Professor</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Museum</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024722664">402-472-2664</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2664</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722664" itemprop="telephone">402-472-2664</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2664</small>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 ppl_Sresult student" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
-                    </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Installer</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">Procurement Services</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024722126">402-472-2126</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2126</small>
-                      </div>
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
                   </div>
                 </li>
-                <li class="dcf-u-mb4 ppl_Sresult student" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult student]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Radio Traffic/Continuity</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Television</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Installer</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Procurement Services</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024729333">402-472-9333</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-9333</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722126" itemprop="telephone">402-472-2126</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2126</small>
                     </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult student]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Radio Traffic/Continuity</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Television</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024729333" itemprop="telephone">402-472-9333</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-9333</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult student]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith106" data-uid="jsmith106" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith106" onclick="return pf_getUID('jsmith106');" aria-label="Show more information about Smith,&nbsp;Jesse">Smith,&nbsp;Jesse</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Windstream Employee</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Office of Information Technology Services</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2014</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2014</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith106?s=small" alt="Avatar for Jesse Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult student]" tabindex="0" data-href="https://directory.unl.edu/people/rsmith53" data-uid="rsmith53" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/rsmith53" onclick="return pf_getUID('rsmith53');" aria-label="Show more information about Smith,&nbsp;Ryan">Smith,&nbsp;Ryan</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">NE College of Technical Agriculture</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-0316</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-0316</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/rsmith53?s=small" alt="Avatar for Ryan Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult student]" tabindex="0" data-href="https://directory.unl.edu/people/ssmith121" data-uid="ssmith121" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/ssmith121" onclick="return pf_getUID('ssmith121');" aria-label="Show more information about Smith,&nbsp;Stephen">Smith,&nbsp;Stephen</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Architect-Kenneth Hahn</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">FM&amp;P Facilities Plan &amp; Construction</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-3131</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-3131</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/ssmith121?s=small" alt="Avatar for Stephen Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult student]" tabindex="0" data-href="https://directory.unl.edu/people/wsmith11" data-uid="wsmith11" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/wsmith11" onclick="return pf_getUID('wsmith11');" aria-label="Show more information about Smith,&nbsp;William">Smith,&nbsp;William</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Entomology</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2123</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2123</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/wsmith11?s=small" alt="Avatar for William Smith">
                   </div>
                 </li>
               </ul>
@@ -545,1068 +842,244 @@
 
             <!-- Volunteers -->
             <div class="dcf-c-search-results__volunteers">
-              <h2 class="dcf-u-mb4 dcf-u-h6"><span class="dcf-u-uppercase dcf-u-ls1">Volunteers</span> <small class="dcf-u-pl2 dcf-u-sm2 dcf-u-regular dcf-u-ls0">6 results found</small></h2>
-              <ul class="dcf-c-list-unstyled pfResult">
-                <li class="dcf-u-mb4 ppl_Sresult volunteer" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
+              <h2 class="dcf-u-mb0 dcf-u-h6 dcf-u-uppercase dcf-u-ls1">Volunteers</h2>
+              <div class="dcf-u-mb7">6 results found</div>
+              <ul class="dcf-c-list-unstyled dcf-u-mb0 pfResult">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult volunteer]" tabindex="0" data-href="https://directory.unl.edu/people/asmith4" data-uid="asmith4" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/asmith4" onclick="return pf_getUID('asmith4');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Research Asst Professor</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Museum</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Research Asst Professor</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Museum</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:+14024722664">402-472-2664</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2664</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722664" itemprop="telephone">402-472-2664</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2664</small>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 ppl_Sresult volunteer" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
-                    </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Installer</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">Procurement Services</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024722126">402-472-2126</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-2126</small>
-                      </div>
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/asmith4?s=small" alt="Avatar for Andrew Smith">
                   </div>
                 </li>
-                <li class="dcf-u-mb4 ppl_Sresult volunteer" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14">
-                  <div class="dcf-u-flex overflow" itemscope="" itemtype="http://schema.org/Person">
-                    <div class="dcf-u-mt1 dcf-u-mr4 profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult volunteer]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith107" data-uid="jsmith107" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith107" onclick="return pf_getUID('jsmith107');" aria-label="Show more information about Smith,&nbsp;Jason">Smith,&nbsp;Jason</a>
                     </div>
-                    <div class="recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn" itemprop="name">
-                        <a itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
-                      </div>
-                      <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled roles">
-                        <li class="org parent-unl">
-                          <span class="dcf-u-block title" itemprop="jobTitle">Radio Traffic/Continuity</span>
-                          <span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-                            <span class="dcf-u-block organization-unit">
-                              <span itemprop="name">University Television</span>
-                            </span>
-                            <span class="dcf-u-block organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization">
-                              <span itemprop="name">University of Nebraska–Lincoln</span>
-                            </span>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Installer</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Procurement Services</span>
                           </span>
-                        </li>
-                      </ul>
-                      <div class="tel">
-                        <a class="dcf-u-mr2" href="tel:4024729333">402-472-9333</a>
-                        <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-9333</small>
-                      </div>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a class="dcf-u-mr2" href="tel:+14024722126" itemprop="telephone">402-472-2126</a>
+                      <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2126</small>
                     </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith107?s=small" alt="Avatar for Jason Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult volunteer]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith14" data-uid="jsmith14" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith14" onclick="return pf_getUID('jsmith14');" aria-label="Show more information about Smith,&nbsp;Jeff">Smith,&nbsp;Jeff</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Radio Traffic/Continuity</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">University Television</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024729333" itemprop="telephone">402-472-9333</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-9333</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith14?s=small" alt="Avatar for Jeff Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult volunteer]" tabindex="0" data-href="https://directory.unl.edu/people/jsmith106" data-uid="jsmith106" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/jsmith106" onclick="return pf_getUID('jsmith106');" aria-label="Show more information about Smith,&nbsp;Jesse">Smith,&nbsp;Jesse</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Windstream Employee</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Office of Information Technology Services</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2014</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2014</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/jsmith106?s=small" alt="Avatar for Jesse Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult volunteer]" tabindex="0" data-href="https://directory.unl.edu/people/rsmith53" data-uid="rsmith53" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/rsmith53" onclick="return pf_getUID('rsmith53');" aria-label="Show more information about Smith,&nbsp;Ryan">Smith,&nbsp;Ryan</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">NE College of Technical Agriculture</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-0316</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-0316</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/rsmith53?s=small" alt="Avatar for Ryan Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult volunteer]" tabindex="0" data-href="https://directory.unl.edu/people/ssmith121" data-uid="ssmith121" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/ssmith121" onclick="return pf_getUID('ssmith121');" aria-label="Show more information about Smith,&nbsp;Stephen">Smith,&nbsp;Stephen</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Architect-Kenneth Hahn</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">FM&amp;P Facilities Plan &amp; Construction</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-3131</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-3131</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/ssmith121?s=small" alt="Avatar for Stephen Smith">
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [ppl_Sresult volunteer]" tabindex="0" data-href="https://directory.unl.edu/people/wsmith11" data-uid="wsmith11" itemscope itemtype="http://schema.org/Person">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]" itemprop="name">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" itemprop="url" href="https://directory.unl.edu/people/wsmith11" onclick="return pf_getUID('wsmith11');" aria-label="Show more information about Smith,&nbsp;William">Smith,&nbsp;William</a>
+                    </div>
+                    <ul class="dcf-u-mt0 dcf-u-mb0 dcf-c-list-unstyled [roles]">
+                      <li class="[org parent-unl]">
+                        <span class="dcf-u-block [title]" itemprop="jobTitle">Affiliate</span>
+                        <span itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
+                          <span class="dcf-u-block [organization-unit]">
+                            <span itemprop="name">Entomology</span>
+                          </span>
+                          <span class="dcf-u-none [organization-name]" itemprop="parentOrganization" itemscope itemtype="http://schema.org/Organization">
+                            <span itemprop="name">University of Nebraska–Lincoln</span>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                    <div class="dcf-u-lh2 [tel]">
+                        <a class="dcf-u-mr2" href="tel:+14024722014" itemprop="telephone">402-472-2123</a>
+                        <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-2123</small>
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" itemprop="image" src="https://directory.unl.edu/avatar/wsmith11?s=small" alt="Avatar for William Smith">
                   </div>
                 </li>
               </ul>
             </div><!-- end Volunteers -->
 
             <!-- Departments -->
-            <div class="dcf-c-search-results__departments results departments">
-              <h2 class="dcf-u-mb4 dcf-u-h6"><span class="dcf-u-uppercase dcf-u-ls1">Departments</span> <small class="dcf-u-pl2 dcf-u-sm2 dcf-u-regular dcf-u-ls0">3 results found</small></h2>
-              <ul class="dcf-c-list-unstyled pfResult departments">
-                <li class="dcf-u-mb4 dep_result parent_264 parent_250" data-href="https://directory.unl.edu/departments/264">
-                  <div class="dcf-u-flex overflow">
-                    <div class="dcf-u-2nd recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn">
-                        <a href="https://directory.unl.edu/departments/264">Harper Schramm Smith Complex</a>
-                      </div>
-                    </div>
-                    <div class="dcf-u-mt1 dcf-u-mr4 dcf-u-1st profile_pic">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://maps.unl.edu/images/building/icon_sm.png" alt="Building Image">
+            <div class="dcf-c-search-results__departments [results departments]">
+              <h2 class="dcf-u-mb0 dcf-u-h6 dcf-u-uppercase dcf-u-ls1">Departments</h2>
+              <div class="dcf-u-mb7">3 results found</div>
+              <ul class="dcf-c-list-unstyled dcf-u-mb0 [pfResult departments]">
+                <li class="dcf-o-media unl-c-directory-result [dep_result parent_264 parent_250]" tabindex="0" data-href="https://directory.unl.edu/departments/264">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" href="https://directory.unl.edu/departments/264">Harper Schramm Smith Complex</a>
                     </div>
                   </div>
-                </li>
-                <li class="dcf-u-mb4 dep_result parent_5697 parent_3519" data-href="https://directory.unl.edu/departments/5697">
-                  <div class="dcf-u-flex overflow">
-                    <div class="dcf-u-2nd recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn">
-                        <a href="https://directory.unl.edu/departments/5697">Smith Hall</a>
-                      </div>
-                      <div class="title">Residence Halls (For Administrative Offices, See University Housing)</div>
-                    </div>
-                    <div class="dcf-u-mt1 dcf-u-mr4 dcf-u-1st profile_pic" href="https://directory.unl.edu/departments/5697">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://maps.unl.edu/building/SMRH/image/1/sm" alt="Building Image">
-                    </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" src="https://maps.unl.edu/images/building/icon_sm.png" alt="Building Image"><!-- better alt value needed -->
                   </div>
                 </li>
-                <li class="dcf-u-mb4 dep_result parent_250 parent_249" data-href="https://directory.unl.edu/departments/250">
-                  <div class="dcf-u-flex overflow">
-                    <div class="dcf-u-2nd recordDetails">
-                      <div class="dcf-u-mb1 dcf-u-h5 dcf-u-bold fn">
-                        <a href="https://directory.unl.edu/departments/250">University Housing</a>
-                      </div>
-                      <div class="tel">
-                        <a href="tel:4024723561">402-472-3561</a> <small class="dcf-u-sm2 dcf-u-txt-nowrap on-campus-dialing">On-campus 2-3561</small>
-                      </div>
+                <li class="dcf-o-media unl-c-directory-result [dep_result parent_5697 parent_3519]" tabindex="0" data-href="https://directory.unl.edu/departments/5697">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" href="https://directory.unl.edu/departments/5697">Smith Hall</a>
                     </div>
-                    <div class="dcf-u-mt1 dcf-u-mr4 dcf-u-1st profile_pic" href="https://directory.unl.edu/departments/250">
-                      <img class="dcf-u-circle photo" itemprop="image" src="https://maps.unl.edu/building/WCDC/image/1/sm" alt="Building Image">
+                    <div class="[title]">Residence Halls (For Administrative Offices, See University Housing)</div><!-- link? -->
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" src="https://maps.unl.edu/building/SMRH/image/1/sm" alt="Building Image"><!-- better alt value needed -->
+                  </div>
+                </li>
+                <li class="dcf-o-media unl-c-directory-result [dep_result parent_250 parent_249]" tabindex="0" data-href="https://directory.unl.edu/departments/250">
+                  <div class="dcf-o-media__body dcf-u-2nd [recordDetails]">
+                    <div class="dcf-u-mb1 [fn]">
+                      <a class="dcf-u-h5 dcf-u-lh2 dcf-u-bold" href="https://directory.unl.edu/departments/5697">University Housing</a>
                     </div>
+                    <div class="dcf-u-lh2 [tel]">
+                      <a href="tel:+14024723561" itemprop="telephone">402-472-3561</a> <small class="dcf-u-sm2 dcf-u-txt-nowrap [on-campus-dialing]">On-campus 2-3561</small><!-- +1 needed for telephone numbers -->
+                    </div>
+                  </div>
+                  <div class="dcf-o-media__object dcf-u-1st dcf-u-mt1 dcf-u-mr5 [profile_pic]">
+                    <img class="dcf-u-w100 dcf-u-circle [photo]" src="https://maps.unl.edu/building/WCDC/image/1/sm" alt="Building Image"><!-- better alt value needed -->
                   </div>
                 </li>
               </ul>
             </div><!-- end Departments -->
 
           </div><!-- end Directory -->
-
-
-
-
-<!--
-
-<div id="results_faculty" class="results affiliation faculty" style="display: block;"><h2 class="wdn-brand">Faculty</h2><div class="result_head">29 results found</div><ul class="pfResult"><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/mhowell2" data-uid="mhowell2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/mhowell2?s=small" alt="Avatar for Michelle Howell Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/mhowell2" onclick="return pf_getUID('mhowell2');" aria-label="Show more information about Howell Smith,&nbsp;Michelle">Howell Smith,&nbsp;Michelle</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Research Assistant Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nebraska Center for Research on Children, Youth, Families &amp; Schools</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721821">
-402-472-1821</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721821"><span class="on-campus-label">On-campus </span>2-1821</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/amessersmith3" data-uid="amessersmith3"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/amessersmith3?s=small" alt="Avatar for Amber Messersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/amessersmith3" onclick="return pf_getUID('amessersmith3');" aria-label="Show more information about Messersmith,&nbsp;Amber">Messersmith,&nbsp;Amber</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Lecturer</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Management</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024725222">
-402-472-5222</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725222"><span class="on-campus-label">On-campus </span>2-5222</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/jmessersmith2" data-uid="jmessersmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jmessersmith2?s=small" alt="Avatar for Jake Messersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jmessersmith2" onclick="return pf_getUID('jmessersmith2');" aria-label="Show more information about Messersmith,&nbsp;Jake">Messersmith,&nbsp;Jake</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Associate Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Management</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Executive Director of Graduate Programs</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Management</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024729171">
-402-472-9171</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024729171"><span class="on-campus-label">On-campus </span>2-9171</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/asmith11" data-uid="asmith11"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith11?s=small" alt="Avatar for Adam Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith11" onclick="return pf_getUID('asmith11');" aria-label="Show more information about Smith,&nbsp;Adam">Smith,&nbsp;Adam</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Asst Forester</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nebraska Forest Service</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721276">
-402-472-1276</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721276"><span class="on-campus-label">On-campus </span>2-1276</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/dsmith19" data-uid="dsmith19"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith19?s=small" alt="Avatar for David Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith19" onclick="return pf_getUID('dsmith19');" aria-label="Show more information about Smith,&nbsp;David">Smith,&nbsp;David</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Coll Prof/Deloitte &amp; Touche Scholar</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">School of Accountancy</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">School of Accountancy</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Coll Prfsp/Raymond C Dein</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">School of Accountancy</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722927">
-402-472-2927</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722927"><span class="on-campus-label">On-campus </span>2-2927</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/dsmith7" data-uid="dsmith7"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith7?s=small" alt="Avatar for David Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith7" onclick="return pf_getUID('dsmith7');" aria-label="Show more information about Smith,&nbsp;David">Smith,&nbsp;David</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Chemistry</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723501">
-402-472-3501</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723501"><span class="on-campus-label">On-campus </span>2-3501</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/dsmith4" data-uid="dsmith4"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith4?s=small" alt="Avatar for David Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith4" onclick="return pf_getUID('dsmith4');" aria-label="Show more information about Smith,&nbsp;David">Smith,&nbsp;David</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Lecturer/T</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">NE College of Technical Agriculture</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Associate Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">NE College of Technical Agriculture</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:3083675284">
-308-367-5284</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 3083675284"><span class="on-campus-label">On-campus </span>7-5284</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/jsmith41" data-uid="jsmith41"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith41?s=small" alt="Avatar for Doug Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith41" onclick="return pf_getUID('jsmith41');" aria-label="Show more information about Smith,&nbsp;Doug">Smith,&nbsp;Doug</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assoc Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">NE College of Technical Agriculture</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Asst Prof of Practice</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Animal Science</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:3083675286">
-308-367-5286</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 3083675286"><span class="on-campus-label">On-campus </span>7-5286</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/dsmith6" data-uid="dsmith6"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith6?s=small" alt="Avatar for Durward Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith6" onclick="return pf_getUID('dsmith6');" aria-label="Show more information about Smith,&nbsp;Durward">Smith,&nbsp;Durward</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assoc Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Food Science &amp; Technology</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722827">
-402-472-2827</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722827"><span class="on-campus-label">On-campus </span>2-2827</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/gsmith5" data-uid="gsmith5"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/gsmith5?s=small" alt="Avatar for Gordon Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/gsmith5" onclick="return pf_getUID('gsmith5');" aria-label="Show more information about Smith,&nbsp;Gordon">Smith,&nbsp;Gordon</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Food Science &amp; Technology</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/hsmith2" data-uid="hsmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/hsmith2?s=small" alt="Avatar for Harris Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/hsmith2" onclick="return pf_getUID('hsmith2');" aria-label="Show more information about Smith,&nbsp;Harris">Smith,&nbsp;Harris</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Director</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Johnny Carson School of Theatre &amp; Film</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Associate Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Johnny Carson School of Theatre &amp; Film</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024727014">
-402-472-7014</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024727014"><span class="on-campus-label">On-campus </span>2-7014</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/jsmith8" data-uid="jsmith8"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith8?s=small" alt="Avatar for Jean Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith8" onclick="return pf_getUID('jsmith8');" aria-label="Show more information about Smith,&nbsp;Jean">Smith,&nbsp;Jean</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle"> Research Profess</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Chemistry</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723501">
-402-472-3501</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723501"><span class="on-campus-label">On-campus </span>2-3501</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/jsmith77" data-uid="jsmith77"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith77?s=small" alt="Avatar for Jeffrey Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith77" onclick="return pf_getUID('jsmith77');" aria-label="Show more information about Smith,&nbsp;Jeffrey">Smith,&nbsp;Jeffrey</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assistant Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Sociology</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723631">
-402-472-3631</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723631"><span class="on-campus-label">On-campus </span>2-3631</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/jsmith5" data-uid="jsmith5"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith5?s=small" alt="Avatar for John Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith5" onclick="return pf_getUID('jsmith5');" aria-label="Show more information about Smith,&nbsp;John">Smith,&nbsp;John</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Biological Systems Engineering</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:3086321230">
-308-632-1230</a></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/ksmith1" data-uid="ksmith1"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith1?s=small" alt="Avatar for Kevin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith1" onclick="return pf_getUID('ksmith1');" aria-label="Show more information about Smith,&nbsp;Kevin">Smith,&nbsp;Kevin</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Political Science</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Chairperson</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Political Science</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024720779">
-402-472-0779</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024720779"><span class="on-campus-label">On-campus </span>2-0779</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/ksmith9" data-uid="ksmith9"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith9?s=small" alt="Avatar for Kirsten Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith9" onclick="return pf_getUID('ksmith9');" aria-label="Show more information about Smith,&nbsp;Kirsten">Smith,&nbsp;Kirsten</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Lecturer/T</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Center for Science, Mathematics &amp; Computer Education</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024728965">
-402-472-8965</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728965"><span class="on-campus-label">On-campus </span>2-8965</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/lsmith6" data-uid="lsmith6"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/lsmith6?s=small" alt="Avatar for L Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/lsmith6" onclick="return pf_getUID('lsmith6');" aria-label="Show more information about Smith,&nbsp;L">Smith,&nbsp;L</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">School of Biological Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/nsmith25" data-uid="nsmith25"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith25?s=small" alt="Avatar for Nancy Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith25" onclick="return pf_getUID('nsmith25');" aria-label="Show more information about Smith,&nbsp;Nancy">Smith,&nbsp;Nancy</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Lecturer/T</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Mathematics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024724395">
-402-472-4395</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724395"><span class="on-campus-label">On-campus </span>2-4395</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/s-nsmith25" data-uid="s-nsmith25"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-nsmith25?s=small" alt="Avatar for Nathan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-nsmith25" onclick="return pf_getUID('s-nsmith25');" aria-label="Show more information about Smith,&nbsp;Nathan">Smith,&nbsp;Nathan</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Post-Doc Rsch Assoc</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Biochemistry</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722658">
-402-472-2658</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722658"><span class="on-campus-label">On-campus </span>2-2658</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/nsmith6" data-uid="nsmith6"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith6?s=small" alt="Avatar for Nicholas Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith6" onclick="return pf_getUID('nsmith6');" aria-label="Show more information about Smith,&nbsp;Nicholas">Smith,&nbsp;Nicholas</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Asst Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Psychology</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024232130">
-402-423-2130</a></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/nsmith2" data-uid="nsmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith2?s=small" alt="Avatar for Nicole Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith2" onclick="return pf_getUID('nsmith2');" aria-label="Show more information about Smith,&nbsp;Nicole">Smith,&nbsp;Nicole</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Modern Languages &amp; Literatures</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723968">
-402-472-3968</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723968"><span class="on-campus-label">On-campus </span>2-3968</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/nsmith3" data-uid="nsmith3"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith3?s=small" alt="Avatar for Norman Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith3" onclick="return pf_getUID('nsmith3');" aria-label="Show more information about Smith,&nbsp;Norman">Smith,&nbsp;Norman</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Earth &amp; Atmospheric Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024725362">
-402-472-5362</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725362"><span class="on-campus-label">On-campus </span>2-5362</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/rsmith11" data-uid="rsmith11"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith11?s=small" alt="Avatar for Russell Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith11" onclick="return pf_getUID('rsmith11');" aria-label="Show more information about Smith,&nbsp;Russell">Smith,&nbsp;Russell</a></div><div class="tel"><a href="tel:4024723677">
-402-472-3677</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723677"><span class="on-campus-label">On-campus </span>2-3677</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/tsmith56" data-uid="tsmith56"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith56?s=small" alt="Avatar for Takako Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith56" onclick="return pf_getUID('tsmith56');" aria-label="Show more information about Smith,&nbsp;Takako">Smith,&nbsp;Takako</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Lecturer</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Programs in English as a Second Language</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721884">
-402-472-1884</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721884"><span class="on-campus-label">On-campus </span>2-1884</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/tgrosserode2" data-uid="tgrosserode2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tgrosserode2?s=small" alt="Avatar for Teresa Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tgrosserode2" onclick="return pf_getUID('tgrosserode2');" aria-label="Show more information about Smith,&nbsp;Teresa">Smith,&nbsp;Teresa</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assistant Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nutrition &amp; Health Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4025590613">
-402-559-0613</a></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/tsmith59" data-uid="tsmith59"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith59?s=small" alt="Avatar for Troy Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith59" onclick="return pf_getUID('tsmith59');" aria-label="Show more information about Smith,&nbsp;Troy">Smith,&nbsp;Troy</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assistant Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Management</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024725628">
-402-472-5628</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725628"><span class="on-campus-label">On-campus </span>2-5628</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/vsmith4" data-uid="vsmith4"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/vsmith4?s=small" alt="Avatar for Victoria Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/vsmith4" onclick="return pf_getUID('vsmith4');" aria-label="Show more information about Smith,&nbsp;Victoria">Smith,&nbsp;Victoria</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Associate Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">History</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Associate Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Ethnic Studies</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722417">
-402-472-2417</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722417"><span class="on-campus-label">On-campus </span>2-2417</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/vsmith2" data-uid="vsmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/vsmith2?s=small" alt="Avatar for Virginia Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/vsmith2" onclick="return pf_getUID('vsmith2');" aria-label="Show more information about Smith,&nbsp;Virginia">Smith,&nbsp;Virginia</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Johnny Carson School of Theatre &amp; Film</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721612">
-402-472-1612</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721612"><span class="on-campus-label">On-campus </span>2-1612</abbr></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/wsmith5" data-uid="wsmith5"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/wsmith5?s=small" alt="Avatar for Wendy Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/wsmith5" onclick="return pf_getUID('wsmith5');" aria-label="Show more information about Smith,&nbsp;Wendy">Smith,&nbsp;Wendy</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Research Associate Professor</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Center for Science, Mathematics &amp; Computer Education</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024728965">
-402-472-8965</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728965"><span class="on-campus-label">On-campus </span>2-8965</abbr></div></div></div></li></ul></div>
-
-
-
-
-<div id="results_staff" class="results affiliation staff" style="display: block;"><h2 class="wdn-brand">Staff</h2><div class="result_head">29 results found</div><ul class="pfResult"><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/ebowersmith2" data-uid="ebowersmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ebowersmith2?s=small" alt="Avatar for Everett Bowersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ebowersmith2" onclick="return pf_getUID('ebowersmith2');" aria-label="Show more information about Bowersmith,&nbsp;Everett">Bowersmith,&nbsp;Everett</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Maint Mech III</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">FM&amp;P Utility Services</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722400">
-402-472-2400</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722400"><span class="on-campus-label">On-campus </span>2-2400</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/dcard-smith2" data-uid="dcard-smith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dcard-smith2?s=small" alt="Avatar for Doris Card-Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dcard-smith2" onclick="return pf_getUID('dcard-smith2');" aria-label="Show more information about Card-Smith,&nbsp;Doris">Card-Smith,&nbsp;Doris</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">CYT Reference Desk Associate</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">University Libraries</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024724407">
-402-472-4407</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724407"><span class="on-campus-label">On-campus </span>2-4407</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/kmonismith2" data-uid="kmonismith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/kmonismith2?s=small" alt="Avatar for Keith Monismith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/kmonismith2" onclick="return pf_getUID('kmonismith2');" aria-label="Show more information about Monismith,&nbsp;Keith">Monismith,&nbsp;Keith</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Application Support Specialist</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Office of the Executive Vice Chancellor and Chief Academic Officer</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024728953">
-402-472-8953</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728953"><span class="on-campus-label">On-campus </span>2-8953</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/asmith2" data-uid="asmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith2?s=small" alt="Avatar for Allen Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith2" onclick="return pf_getUID('asmith2');" aria-label="Show more information about Smith,&nbsp;Allen">Smith,&nbsp;Allen</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Custodian II</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">FM&amp;P Custodial Services</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723175">
-402-472-3175</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723175"><span class="on-campus-label">On-campus </span>2-3175</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/bsmith53" data-uid="bsmith53"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith53?s=small" alt="Avatar for Bradley Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith53" onclick="return pf_getUID('bsmith53');" aria-label="Show more information about Smith,&nbsp;Bradley">Smith,&nbsp;Bradley</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Asst Dir of Sports Analytics-Analysis</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024728030">
-402-472-8030</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728030"><span class="on-campus-label">On-campus </span>2-8030</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/csmith116" data-uid="csmith116"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith116?s=small" alt="Avatar for Christine Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith116" onclick="return pf_getUID('csmith116');" aria-label="Show more information about Smith,&nbsp;Christine">Smith,&nbsp;Christine</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Rsch Technologist I</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Agronomy &amp; Horticulture</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024725292">
-402-472-5292</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725292"><span class="on-campus-label">On-campus </span>2-5292</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/dsmith11" data-uid="dsmith11"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith11?s=small" alt="Avatar for Dan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith11" onclick="return pf_getUID('dsmith11');" aria-label="Show more information about Smith,&nbsp;Dan">Smith,&nbsp;Dan</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Camera Operator</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">University Television</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024729333">
-402-472-9333</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024729333"><span class="on-campus-label">On-campus </span>2-9333</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/dsmith20" data-uid="dsmith20"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith20?s=small" alt="Avatar for Dennis Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith20" onclick="return pf_getUID('dsmith20');" aria-label="Show more information about Smith,&nbsp;Dennis">Smith,&nbsp;Dennis</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Liaison Coordinator</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nebraska LTAP</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024793897">
-402-479-3897</a></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/dsmith18" data-uid="dsmith18"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith18?s=small" alt="Avatar for Douglas Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith18" onclick="return pf_getUID('dsmith18');" aria-label="Show more information about Smith,&nbsp;Douglas">Smith,&nbsp;Douglas</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">O/S On Call Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Johnny Carson School of Theatre &amp; Film</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721612">
-402-472-1612</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721612"><span class="on-campus-label">On-campus </span>2-1612</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/esmith30" data-uid="esmith30"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith30?s=small" alt="Avatar for Earl Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith30" onclick="return pf_getUID('esmith30');" aria-label="Show more information about Smith,&nbsp;Earl">Smith,&nbsp;Earl</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">O/S On Call Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">O/S On Call Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">O/S On Call Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721960">
-402-472-1960</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721960"><span class="on-campus-label">On-campus </span>2-1960</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/jsmith124" data-uid="jsmith124"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith124?s=small" alt="Avatar for Jerry Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith124" onclick="return pf_getUID('jsmith124');" aria-label="Show more information about Smith,&nbsp;Jerry">Smith,&nbsp;Jerry</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">O/S On Call Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">West Central Research &amp; Extension Center</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:3088895555">
-308-889-5555</a></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/jsmith20" data-uid="jsmith20"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith20?s=small" alt="Avatar for JR Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith20" onclick="return pf_getUID('jsmith20');" aria-label="Show more information about Smith,&nbsp;JR">Smith,&nbsp;JR</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Custodial Leader</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Campus Recreation</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723467">
-402-472-3467</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723467"><span class="on-campus-label">On-campus </span>2-3467</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/ksmith2" data-uid="ksmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith2?s=small" alt="Avatar for Kelly Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith2" onclick="return pf_getUID('ksmith2');" aria-label="Show more information about Smith,&nbsp;Kelly">Smith,&nbsp;Kelly</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Specialist Drought Resources</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">School of Natural Resources</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723373">
-402-472-3373</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723373"><span class="on-campus-label">On-campus </span>2-3373</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/ksmith16" data-uid="ksmith16"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith16?s=small" alt="Avatar for Kenneth Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith16" onclick="return pf_getUID('ksmith16');" aria-label="Show more information about Smith,&nbsp;Kenneth">Smith,&nbsp;Kenneth</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Chief Util Oper</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">FM&amp;P Utility Services</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024724014">
-402-472-4014</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724014"><span class="on-campus-label">On-campus </span>2-4014</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/s-kgolden3" data-uid="s-kgolden3"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-kgolden3?s=small" alt="Avatar for Kimberly Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-kgolden3" onclick="return pf_getUID('s-kgolden3');" aria-label="Show more information about Smith,&nbsp;Kimberly">Smith,&nbsp;Kimberly</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Asst Dir of Comm, Mktg &amp; Ext Relations</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Business</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024720128">
-402-472-0128</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024720128"><span class="on-campus-label">On-campus </span>2-0128</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/msmith10" data-uid="msmith10"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith10?s=small" alt="Avatar for Mary Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith10" onclick="return pf_getUID('msmith10');" aria-label="Show more information about Smith,&nbsp;Mary">Smith,&nbsp;Mary</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Custodian II</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">FM&amp;P Custodial Services</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723175">
-402-472-3175</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723175"><span class="on-campus-label">On-campus </span>2-3175</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/msmith9" data-uid="msmith9"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith9?s=small" alt="Avatar for Matt Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith9" onclick="return pf_getUID('msmith9');" aria-label="Show more information about Smith,&nbsp;Matt">Smith,&nbsp;Matt</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assoc Communications Dir/Strategic Rsch</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722263">
-402-472-2263</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722263"><span class="on-campus-label">On-campus </span>2-2263</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/msmith43" data-uid="msmith43"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith43?s=small" alt="Avatar for Monte Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith43" onclick="return pf_getUID('msmith43');" aria-label="Show more information about Smith,&nbsp;Monte">Smith,&nbsp;Monte</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Custodian II</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">FM&amp;P Custodial Services</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4023090073">
-402-309-0073</a></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/nsmith18" data-uid="nsmith18"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith18?s=small" alt="Avatar for Natalie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith18" onclick="return pf_getUID('nsmith18');" aria-label="Show more information about Smith,&nbsp;Natalie">Smith,&nbsp;Natalie</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assistant Registrar</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Sheldon Museum of Art</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722461">
-402-472-2461</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722461"><span class="on-campus-label">On-campus </span>2-2461</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/nsmith7" data-uid="nsmith7"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith7?s=small" alt="Avatar for Nicole Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith7" onclick="return pf_getUID('nsmith7');" aria-label="Show more information about Smith,&nbsp;Nicole">Smith,&nbsp;Nicole</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Development Coord</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Agricultural Sciences and Natural Resources</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024720609">
-402-472-0609</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024720609"><span class="on-campus-label">On-campus </span>2-0609</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/psmith1" data-uid="psmith1"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/psmith1?s=small" alt="Avatar for Pat Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/psmith1" onclick="return pf_getUID('psmith1');" aria-label="Show more information about Smith,&nbsp;Pat">Smith,&nbsp;Pat</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Non-Resident Alien Payroll Specialist</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Payroll Services</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722010">
-402-472-2010</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722010"><span class="on-campus-label">On-campus </span>2-2010</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/rsmith42" data-uid="rsmith42"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith42?s=small" alt="Avatar for Riley Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith42" onclick="return pf_getUID('rsmith42');" aria-label="Show more information about Smith,&nbsp;Riley">Smith,&nbsp;Riley</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Database Administrator/Programmer</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Arts &amp; Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:308/2581609">
-308/2581609</a></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/ssmith1" data-uid="ssmith1"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith1?s=small" alt="Avatar for Sheila Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith1" onclick="return pf_getUID('ssmith1');" aria-label="Show more information about Smith,&nbsp;Sheila">Smith,&nbsp;Sheila</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Illustrator</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Biological Systems Engineering</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723179">
-402-472-3179</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723179"><span class="on-campus-label">On-campus </span>2-3179</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/ssmith57" data-uid="ssmith57"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith57?s=small" alt="Avatar for Susan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith57" onclick="return pf_getUID('ssmith57');" aria-label="Show more information about Smith,&nbsp;Susan">Smith,&nbsp;Susan</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">O/S On Call Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721960">
-402-472-1960</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721960"><span class="on-campus-label">On-campus </span>2-1960</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/s-tsmith55" data-uid="s-tsmith55"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-tsmith55?s=small" alt="Avatar for Thomas Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-tsmith55" onclick="return pf_getUID('s-tsmith55');" aria-label="Show more information about Smith,&nbsp;Thomas">Smith,&nbsp;Thomas</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Assistant Director</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Chemistry</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723797">
-402-472-3797</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723797"><span class="on-campus-label">On-campus </span>2-3797</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/tsmith24" data-uid="tsmith24"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith24?s=small" alt="Avatar for Tina Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith24" onclick="return pf_getUID('tsmith24');" aria-label="Show more information about Smith,&nbsp;Tina">Smith,&nbsp;Tina</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Admissions Recruiting Coord</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">NE College of Technical Agriculture</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:3083675267">
-308-367-5267</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 3083675267"><span class="on-campus-label">On-campus </span>7-5267</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/tsmith12" data-uid="tsmith12"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith12?s=small" alt="Avatar for Tyler Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith12" onclick="return pf_getUID('tsmith12');" aria-label="Show more information about Smith,&nbsp;Tyler">Smith,&nbsp;Tyler</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Rsch Technologist II</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Biological Systems Engineering</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024726282">
-402-472-6282</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024726282"><span class="on-campus-label">On-campus </span>2-6282</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/ysmith2" data-uid="ysmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ysmith2?s=small" alt="Avatar for Yoko Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ysmith2" onclick="return pf_getUID('ysmith2');" aria-label="Show more information about Smith,&nbsp;Yoko">Smith,&nbsp;Yoko</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Occupational Safety Technician</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Environmental Health &amp; Safety</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024726512">
-402-472-6512</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024726512"><span class="on-campus-label">On-campus </span>2-6512</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/zsmith7" data-uid="zsmith7"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/zsmith7?s=small" alt="Avatar for Zachary Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/zsmith7" onclick="return pf_getUID('zsmith7');" aria-label="Show more information about Smith,&nbsp;Zachary">Smith,&nbsp;Zachary</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">M/P Temporary Worker Hourly</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Physics &amp; Astronomy</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722770">
-402-472-2770</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722770"><span class="on-campus-label">On-campus </span>2-2770</abbr></div></div></div></li></ul></div>
-
-
-
-
-<div id="results_student" class="results affiliation student" style="display: block;"><h2 class="wdn-brand">Student</h2><div class="result_head">178 results found</div><ul class="pfResult"><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/marrasmith3" data-uid="marrasmith3"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/marrasmith3?s=small" alt="Avatar for Michael Arrasmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/marrasmith3" onclick="return pf_getUID('marrasmith3');" aria-label="Show more information about Arrasmith,&nbsp;Michael">Arrasmith,&nbsp;Michael</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/marrowsmith2" data-uid="marrowsmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/marrowsmith2?s=small" alt="Avatar for Mirannda Arrowsmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/marrowsmith2" onclick="return pf_getUID('marrowsmith2');" aria-label="Show more information about Arrowsmith,&nbsp;Mirannda">Arrowsmith,&nbsp;Mirannda</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ccoppersmith2" data-uid="ccoppersmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ccoppersmith2?s=small" alt="Avatar for Claire Coppersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ccoppersmith2" onclick="return pf_getUID('ccoppersmith2');" aria-label="Show more information about Coppersmith,&nbsp;Claire">Coppersmith,&nbsp;Claire</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/s-zcopper1" data-uid="s-zcopper1"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-zcopper1?s=small" alt="Avatar for Zachary Coppersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-zcopper1" onclick="return pf_getUID('s-zcopper1');" aria-label="Show more information about Coppersmith,&nbsp;Zachary">Coppersmith,&nbsp;Zachary</a></div><div class="tel"><a href="tel:4024722023">
-402-472-2023</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722023"><span class="on-campus-label">On-campus </span>2-2023</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/agoldsmith2" data-uid="agoldsmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/agoldsmith2?s=small" alt="Avatar for Andrew Goldsmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/agoldsmith2" onclick="return pf_getUID('agoldsmith2');" aria-label="Show more information about Goldsmith,&nbsp;Andrew">Goldsmith,&nbsp;Andrew</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Architecture</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024729212">
-402-472-9212</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024729212"><span class="on-campus-label">On-campus </span>2-9212</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bgoldsmith2" data-uid="bgoldsmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bgoldsmith2?s=small" alt="Avatar for Bryanna Goldsmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bgoldsmith2" onclick="return pf_getUID('bgoldsmith2');" aria-label="Show more information about Goldsmith,&nbsp;Bryanna">Goldsmith,&nbsp;Bryanna</a></div><div class="tel"><a href="tel:4024723659">
-402-472-3659</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723659"><span class="on-campus-label">On-campus </span>2-3659</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/wgrattan-smith2" data-uid="wgrattan-smith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/wgrattan-smith2?s=small" alt="Avatar for William Grattan-Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/wgrattan-smith2" onclick="return pf_getUID('wgrattan-smith2');" aria-label="Show more information about Grattan-Smith,&nbsp;William">Grattan-Smith,&nbsp;William</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/elevos-smith2" data-uid="elevos-smith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/elevos-smith2?s=small" alt="Avatar for Emily Levos-Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/elevos-smith2" onclick="return pf_getUID('elevos-smith2');" aria-label="Show more information about Levos-Smith,&nbsp;Emily">Levos-Smith,&nbsp;Emily</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/elitel-smith2" data-uid="elitel-smith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/elitel-smith2?s=small" alt="Avatar for Emily Litel-Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/elitel-smith2" onclick="return pf_getUID('elitel-smith2');" aria-label="Show more information about Litel-Smith,&nbsp;Emily">Litel-Smith,&nbsp;Emily</a></div><div class="tel"><a href="tel:402/7083617">
-402/7083617</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/smercer-smith3" data-uid="smercer-smith3"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/smercer-smith3?s=small" alt="Avatar for Soren Mercer-Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/smercer-smith3" onclick="return pf_getUID('smercer-smith3');" aria-label="Show more information about Mercer-Smith,&nbsp;Soren">Mercer-Smith,&nbsp;Soren</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/amessersmith4" data-uid="amessersmith4"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/amessersmith4?s=small" alt="Avatar for Andrew Messersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/amessersmith4" onclick="return pf_getUID('amessersmith4');" aria-label="Show more information about Messersmith,&nbsp;Andrew">Messersmith,&nbsp;Andrew</a></div><div class="tel"><a href="tel:308/3457122">
-308/3457122</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dmessersmith2" data-uid="dmessersmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dmessersmith2?s=small" alt="Avatar for Derek Messersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dmessersmith2" onclick="return pf_getUID('dmessersmith2');" aria-label="Show more information about Messersmith,&nbsp;Derek">Messersmith,&nbsp;Derek</a></div><div class="tel"><a href="tel:402/6815743">
-402/6815743</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/pmessersmith2" data-uid="pmessersmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/pmessersmith2?s=small" alt="Avatar for Patrick Messersmith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/pmessersmith2" onclick="return pf_getUID('pmessersmith2');" aria-label="Show more information about Messersmith,&nbsp;Patrick">Messersmith,&nbsp;Patrick</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith80" data-uid="asmith80"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith80?s=small" alt="Avatar for Abigail Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith80" onclick="return pf_getUID('asmith80');" aria-label="Show more information about Smith,&nbsp;Abigail">Smith,&nbsp;Abigail</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith52" data-uid="asmith52"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith52?s=small" alt="Avatar for Abigail Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith52" onclick="return pf_getUID('asmith52');" aria-label="Show more information about Smith,&nbsp;Abigail">Smith,&nbsp;Abigail</a></div><div class="tel"><a href="tel:4024725540">
-402-472-5540</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725540"><span class="on-campus-label">On-campus </span>2-5540</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith54" data-uid="asmith54"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith54?s=small" alt="Avatar for Abigail Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith54" onclick="return pf_getUID('asmith54');" aria-label="Show more information about Smith,&nbsp;Abigail">Smith,&nbsp;Abigail</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith78" data-uid="asmith78"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith78?s=small" alt="Avatar for Alice Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith78" onclick="return pf_getUID('asmith78');" aria-label="Show more information about Smith,&nbsp;Alice">Smith,&nbsp;Alice</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith51" data-uid="asmith51"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith51?s=small" alt="Avatar for Allison Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith51" onclick="return pf_getUID('asmith51');" aria-label="Show more information about Smith,&nbsp;Allison">Smith,&nbsp;Allison</a></div><div class="tel"><a href="tel:4024729214">
-402-472-9214</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024729214"><span class="on-campus-label">On-campus </span>2-9214</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith77" data-uid="asmith77"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith77?s=small" alt="Avatar for Amanda Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith77" onclick="return pf_getUID('asmith77');" aria-label="Show more information about Smith,&nbsp;Amanda">Smith,&nbsp;Amanda</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith82" data-uid="asmith82"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith82?s=small" alt="Avatar for Andrew Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith82" onclick="return pf_getUID('asmith82');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a></div><div class="tel"><a href="tel:402/4167121">
-402/4167121</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith70" data-uid="asmith70"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith70?s=small" alt="Avatar for Andrew Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith70" onclick="return pf_getUID('asmith70');" aria-label="Show more information about Smith,&nbsp;Andrew">Smith,&nbsp;Andrew</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/asmith72" data-uid="asmith72"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith72?s=small" alt="Avatar for Autumn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith72" onclick="return pf_getUID('asmith72');" aria-label="Show more information about Smith,&nbsp;Autumn">Smith,&nbsp;Autumn</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith54" data-uid="bsmith54"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith54?s=small" alt="Avatar for Bailee Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith54" onclick="return pf_getUID('bsmith54');" aria-label="Show more information about Smith,&nbsp;Bailee">Smith,&nbsp;Bailee</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith32" data-uid="bsmith32"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith32?s=small" alt="Avatar for Benjamin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith32" onclick="return pf_getUID('bsmith32');" aria-label="Show more information about Smith,&nbsp;Benjamin">Smith,&nbsp;Benjamin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith60" data-uid="bsmith60"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith60?s=small" alt="Avatar for Benjamin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith60" onclick="return pf_getUID('bsmith60');" aria-label="Show more information about Smith,&nbsp;Benjamin">Smith,&nbsp;Benjamin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith17" data-uid="bsmith17"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith17?s=small" alt="Avatar for Benjamin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith17" onclick="return pf_getUID('bsmith17');" aria-label="Show more information about Smith,&nbsp;Benjamin">Smith,&nbsp;Benjamin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith20" data-uid="bsmith20"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith20?s=small" alt="Avatar for Bonnie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith20" onclick="return pf_getUID('bsmith20');" aria-label="Show more information about Smith,&nbsp;Bonnie">Smith,&nbsp;Bonnie</a></div><div class="tel"><a href="tel:4024361166">
-402-436-1166</a></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/bsmith53" data-uid="bsmith53"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith53?s=small" alt="Avatar for Bradley Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith53" onclick="return pf_getUID('bsmith53');" aria-label="Show more information about Smith,&nbsp;Bradley">Smith,&nbsp;Bradley</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Asst Dir of Sports Analytics-Analysis</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024728030">
-402-472-8030</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728030"><span class="on-campus-label">On-campus </span>2-8030</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith57" data-uid="bsmith57"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith57?s=small" alt="Avatar for Brandon Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith57" onclick="return pf_getUID('bsmith57');" aria-label="Show more information about Smith,&nbsp;Brandon">Smith,&nbsp;Brandon</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Business</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722208">
-402-472-2208</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722208"><span class="on-campus-label">On-campus </span>2-2208</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith55" data-uid="bsmith55"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith55?s=small" alt="Avatar for Breanna Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith55" onclick="return pf_getUID('bsmith55');" aria-label="Show more information about Smith,&nbsp;Breanna">Smith,&nbsp;Breanna</a></div><div class="title" itemprop="jobTitle">Student Worker</div><div class="tel"><a href="tel:402/5543859">
-402/5543859</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith61" data-uid="bsmith61"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith61?s=small" alt="Avatar for Brett Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith61" onclick="return pf_getUID('bsmith61');" aria-label="Show more information about Smith,&nbsp;Brett">Smith,&nbsp;Brett</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith43" data-uid="bsmith43"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith43?s=small" alt="Avatar for Brian Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith43" onclick="return pf_getUID('bsmith43');" aria-label="Show more information about Smith,&nbsp;Brian">Smith,&nbsp;Brian</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">UCARE Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Education &amp; Human Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723716">
-402-472-3716</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723716"><span class="on-campus-label">On-campus </span>2-3716</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith59" data-uid="bsmith59"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith59?s=small" alt="Avatar for Brianna Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith59" onclick="return pf_getUID('bsmith59');" aria-label="Show more information about Smith,&nbsp;Brianna">Smith,&nbsp;Brianna</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Graduate Teaching Asst</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Glenn Korff School of Music</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722503">
-402-472-2503</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722503"><span class="on-campus-label">On-campus </span>2-2503</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith56" data-uid="bsmith56"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith56?s=small" alt="Avatar for Brianna Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith56" onclick="return pf_getUID('bsmith56');" aria-label="Show more information about Smith,&nbsp;Brianna">Smith,&nbsp;Brianna</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Engineering</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722009">
-402-472-2009</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722009"><span class="on-campus-label">On-campus </span>2-2009</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith49" data-uid="bsmith49"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith49?s=small" alt="Avatar for Brooke Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith49" onclick="return pf_getUID('bsmith49');" aria-label="Show more information about Smith,&nbsp;Brooke">Smith,&nbsp;Brooke</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/bsmith42" data-uid="bsmith42"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/bsmith42?s=small" alt="Avatar for Brooke Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/bsmith42" onclick="return pf_getUID('bsmith42');" aria-label="Show more information about Smith,&nbsp;Brooke">Smith,&nbsp;Brooke</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith149" data-uid="csmith149"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith149?s=small" alt="Avatar for Caitlin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith149" onclick="return pf_getUID('csmith149');" aria-label="Show more information about Smith,&nbsp;Caitlin">Smith,&nbsp;Caitlin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith156" data-uid="csmith156"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith156?s=small" alt="Avatar for Caleb Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith156" onclick="return pf_getUID('csmith156');" aria-label="Show more information about Smith,&nbsp;Caleb">Smith,&nbsp;Caleb</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith113" data-uid="csmith113"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith113?s=small" alt="Avatar for Caleb Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith113" onclick="return pf_getUID('csmith113');" aria-label="Show more information about Smith,&nbsp;Caleb">Smith,&nbsp;Caleb</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024727880">
-402-472-7880</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024727880"><span class="on-campus-label">On-campus </span>2-7880</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith76" data-uid="csmith76"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith76?s=small" alt="Avatar for Cameron Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith76" onclick="return pf_getUID('csmith76');" aria-label="Show more information about Smith,&nbsp;Cameron">Smith,&nbsp;Cameron</a></div><div class="tel"><a href="tel:4024723571">
-402-472-3571</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723571"><span class="on-campus-label">On-campus </span>2-3571</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith141" data-uid="csmith141"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith141?s=small" alt="Avatar for Carly Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith141" onclick="return pf_getUID('csmith141');" aria-label="Show more information about Smith,&nbsp;Carly">Smith,&nbsp;Carly</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith124" data-uid="csmith124"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith124?s=small" alt="Avatar for Carly Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith124" onclick="return pf_getUID('csmith124');" aria-label="Show more information about Smith,&nbsp;Carly">Smith,&nbsp;Carly</a></div><div class="tel"><a href="tel:4024728698">
-402-472-8698</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728698"><span class="on-campus-label">On-campus </span>2-8698</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/s-cmccue1" data-uid="s-cmccue1"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-cmccue1?s=small" alt="Avatar for Carmen Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-cmccue1" onclick="return pf_getUID('s-cmccue1');" aria-label="Show more information about Smith,&nbsp;Carmen">Smith,&nbsp;Carmen</a></div><div class="tel"><a href="tel:4024723191">
-402-472-3191</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723191"><span class="on-campus-label">On-campus </span>2-3191</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith129" data-uid="csmith129"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith129?s=small" alt="Avatar for Casey Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith129" onclick="return pf_getUID('csmith129');" aria-label="Show more information about Smith,&nbsp;Casey">Smith,&nbsp;Casey</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024724880">
-402-472-4880</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724880"><span class="on-campus-label">On-campus </span>2-4880</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith26" data-uid="csmith26"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith26?s=small" alt="Avatar for Catherine Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith26" onclick="return pf_getUID('csmith26');" aria-label="Show more information about Smith,&nbsp;Catherine">Smith,&nbsp;Catherine</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith154" data-uid="csmith154"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith154?s=small" alt="Avatar for Chad Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith154" onclick="return pf_getUID('csmith154');" aria-label="Show more information about Smith,&nbsp;Chad">Smith,&nbsp;Chad</a></div><div class="tel"><a href="tel:4024723305">
-402-472-3305</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723305"><span class="on-campus-label">On-campus </span>2-3305</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith130" data-uid="csmith130"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith130?s=small" alt="Avatar for Chandler Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith130" onclick="return pf_getUID('csmith130');" aria-label="Show more information about Smith,&nbsp;Chandler">Smith,&nbsp;Chandler</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith140" data-uid="csmith140"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith140?s=small" alt="Avatar for Chandra Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith140" onclick="return pf_getUID('csmith140');" aria-label="Show more information about Smith,&nbsp;Chandra">Smith,&nbsp;Chandra</a></div><div class="tel"><a href="tel:4024723672">
-402-472-3672</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723672"><span class="on-campus-label">On-campus </span>2-3672</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith74" data-uid="csmith74"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith74?s=small" alt="Avatar for Christina Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith74" onclick="return pf_getUID('csmith74');" aria-label="Show more information about Smith,&nbsp;Christina">Smith,&nbsp;Christina</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith133" data-uid="csmith133"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith133?s=small" alt="Avatar for Christopher Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith133" onclick="return pf_getUID('csmith133');" aria-label="Show more information about Smith,&nbsp;Christopher">Smith,&nbsp;Christopher</a></div><div class="tel"><a href="tel:3086966735">
-308-696-6735</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 3086966735"><span class="on-campus-label">On-campus </span>7-6735</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith146" data-uid="csmith146"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith146?s=small" alt="Avatar for Clare Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith146" onclick="return pf_getUID('csmith146');" aria-label="Show more information about Smith,&nbsp;Clare">Smith,&nbsp;Clare</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">NE College of Technical Agriculture</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:3083674124">
-308-367-4124</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith138" data-uid="csmith138"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith138?s=small" alt="Avatar for Cody Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith138" onclick="return pf_getUID('csmith138');" aria-label="Show more information about Smith,&nbsp;Cody">Smith,&nbsp;Cody</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith151" data-uid="csmith151"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith151?s=small" alt="Avatar for Cody Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith151" onclick="return pf_getUID('csmith151');" aria-label="Show more information about Smith,&nbsp;Cody">Smith,&nbsp;Cody</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith135" data-uid="csmith135"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith135?s=small" alt="Avatar for Cole Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith135" onclick="return pf_getUID('csmith135');" aria-label="Show more information about Smith,&nbsp;Cole">Smith,&nbsp;Cole</a></div><div class="tel"><a href="tel:402/2165088">
-402/2165088</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith147" data-uid="csmith147"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith147?s=small" alt="Avatar for Cole Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith147" onclick="return pf_getUID('csmith147');" aria-label="Show more information about Smith,&nbsp;Cole">Smith,&nbsp;Cole</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith125" data-uid="csmith125"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith125?s=small" alt="Avatar for Cory Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith125" onclick="return pf_getUID('csmith125');" aria-label="Show more information about Smith,&nbsp;Cory">Smith,&nbsp;Cory</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Graduate Research Asst</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nutrition &amp; Health Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Graduate Teaching Asst</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nutrition &amp; Health Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723716">
-402-472-3716</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723716"><span class="on-campus-label">On-campus </span>2-3716</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith148" data-uid="csmith148"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith148?s=small" alt="Avatar for Courtney Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith148" onclick="return pf_getUID('csmith148');" aria-label="Show more information about Smith,&nbsp;Courtney">Smith,&nbsp;Courtney</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/csmith145" data-uid="csmith145"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/csmith145?s=small" alt="Avatar for Cullen Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/csmith145" onclick="return pf_getUID('csmith145');" aria-label="Show more information about Smith,&nbsp;Cullen">Smith,&nbsp;Cullen</a></div><div class="tel"><a href="tel:402/9835728">
-402/9835728</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dsmith118" data-uid="dsmith118"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith118?s=small" alt="Avatar for Dallas Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith118" onclick="return pf_getUID('dsmith118');" aria-label="Show more information about Smith,&nbsp;Dallas">Smith,&nbsp;Dallas</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dsmith124" data-uid="dsmith124"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith124?s=small" alt="Avatar for Dani Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith124" onclick="return pf_getUID('dsmith124');" aria-label="Show more information about Smith,&nbsp;Dani">Smith,&nbsp;Dani</a></div><div class="tel"><a href="tel:4024726714">
-402-472-6714</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024726714"><span class="on-campus-label">On-campus </span>2-6714</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dsmith114" data-uid="dsmith114"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith114?s=small" alt="Avatar for Darrin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith114" onclick="return pf_getUID('dsmith114');" aria-label="Show more information about Smith,&nbsp;Darrin">Smith,&nbsp;Darrin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dsmith120" data-uid="dsmith120"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith120?s=small" alt="Avatar for Derek Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith120" onclick="return pf_getUID('dsmith120');" aria-label="Show more information about Smith,&nbsp;Derek">Smith,&nbsp;Derek</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dsmith130" data-uid="dsmith130"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith130?s=small" alt="Avatar for Devin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith130" onclick="return pf_getUID('dsmith130');" aria-label="Show more information about Smith,&nbsp;Devin">Smith,&nbsp;Devin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dsmith121" data-uid="dsmith121"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith121?s=small" alt="Avatar for Donovan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith121" onclick="return pf_getUID('dsmith121');" aria-label="Show more information about Smith,&nbsp;Donovan">Smith,&nbsp;Donovan</a></div><div class="tel"><a href="tel:308/3836831">
-308/3836831</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/dsmith128" data-uid="dsmith128"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith128?s=small" alt="Avatar for Donovan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith128" onclick="return pf_getUID('dsmith128');" aria-label="Show more information about Smith,&nbsp;Donovan">Smith,&nbsp;Donovan</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024726462">
-402-472-6462</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024726462"><span class="on-campus-label">On-campus </span>2-6462</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith48" data-uid="esmith48"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith48?s=small" alt="Avatar for Emily Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith48" onclick="return pf_getUID('esmith48');" aria-label="Show more information about Smith,&nbsp;Emily">Smith,&nbsp;Emily</a></div><div class="tel"><a href="tel:3083674124">
-308-367-4124</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith39" data-uid="esmith39"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith39?s=small" alt="Avatar for Emily Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith39" onclick="return pf_getUID('esmith39');" aria-label="Show more information about Smith,&nbsp;Emily">Smith,&nbsp;Emily</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith54" data-uid="esmith54"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith54?s=small" alt="Avatar for Emily Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith54" onclick="return pf_getUID('esmith54');" aria-label="Show more information about Smith,&nbsp;Emily">Smith,&nbsp;Emily</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith40" data-uid="esmith40"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith40?s=small" alt="Avatar for Emma Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith40" onclick="return pf_getUID('esmith40');" aria-label="Show more information about Smith,&nbsp;Emma">Smith,&nbsp;Emma</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith46" data-uid="esmith46"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith46?s=small" alt="Avatar for Emma Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith46" onclick="return pf_getUID('esmith46');" aria-label="Show more information about Smith,&nbsp;Emma">Smith,&nbsp;Emma</a></div><div class="tel"><a href="tel:4024723467">
-402-472-3467</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723467"><span class="on-campus-label">On-campus </span>2-3467</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith44" data-uid="esmith44"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith44?s=small" alt="Avatar for Evelyn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith44" onclick="return pf_getUID('esmith44');" aria-label="Show more information about Smith,&nbsp;Evelyn">Smith,&nbsp;Evelyn</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith38" data-uid="esmith38"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith38?s=small" alt="Avatar for Evie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith38" onclick="return pf_getUID('esmith38');" aria-label="Show more information about Smith,&nbsp;Evie">Smith,&nbsp;Evie</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/fsmith5" data-uid="fsmith5"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/fsmith5?s=small" alt="Avatar for Franklyn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/fsmith5" onclick="return pf_getUID('fsmith5');" aria-label="Show more information about Smith,&nbsp;Franklyn">Smith,&nbsp;Franklyn</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/gsmith40" data-uid="gsmith40"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/gsmith40?s=small" alt="Avatar for Gabbi Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/gsmith40" onclick="return pf_getUID('gsmith40');" aria-label="Show more information about Smith,&nbsp;Gabbi">Smith,&nbsp;Gabbi</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/gsmith23" data-uid="gsmith23"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/gsmith23?s=small" alt="Avatar for Garrett Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/gsmith23" onclick="return pf_getUID('gsmith23');" aria-label="Show more information about Smith,&nbsp;Garrett">Smith,&nbsp;Garrett</a></div><div class="tel"><a href="tel:402/5930237">
-402/5930237</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/gsmith9" data-uid="gsmith9"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/gsmith9?s=small" alt="Avatar for Gregory Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/gsmith9" onclick="return pf_getUID('gsmith9');" aria-label="Show more information about Smith,&nbsp;Gregory">Smith,&nbsp;Gregory</a></div><div class="tel"><a href="tel:4024729333">
-402-472-9333</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024729333"><span class="on-campus-label">On-campus </span>2-9333</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/hsmith16" data-uid="hsmith16"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/hsmith16?s=small" alt="Avatar for Hailey Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/hsmith16" onclick="return pf_getUID('hsmith16');" aria-label="Show more information about Smith,&nbsp;Hailey">Smith,&nbsp;Hailey</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/hsmith27" data-uid="hsmith27"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/hsmith27?s=small" alt="Avatar for Harrison Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/hsmith27" onclick="return pf_getUID('hsmith27');" aria-label="Show more information about Smith,&nbsp;Harrison">Smith,&nbsp;Harrison</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/hsmith22" data-uid="hsmith22"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/hsmith22?s=small" alt="Avatar for Heather Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/hsmith22" onclick="return pf_getUID('hsmith22');" aria-label="Show more information about Smith,&nbsp;Heather">Smith,&nbsp;Heather</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024724886">
-402-472-4886</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724886"><span class="on-campus-label">On-campus </span>2-4886</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/s-hsmith16" data-uid="s-hsmith16"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-hsmith16?s=small" alt="Avatar for Hezekiah Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-hsmith16" onclick="return pf_getUID('s-hsmith16');" aria-label="Show more information about Smith,&nbsp;Hezekiah">Smith,&nbsp;Hezekiah</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/hsmith26" data-uid="hsmith26"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/hsmith26?s=small" alt="Avatar for Hunter Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/hsmith26" onclick="return pf_getUID('hsmith26');" aria-label="Show more information about Smith,&nbsp;Hunter">Smith,&nbsp;Hunter</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith120" data-uid="jsmith120"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith120?s=small" alt="Avatar for Jackson Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith120" onclick="return pf_getUID('jsmith120');" aria-label="Show more information about Smith,&nbsp;Jackson">Smith,&nbsp;Jackson</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith119" data-uid="jsmith119"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith119?s=small" alt="Avatar for Jackson Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith119" onclick="return pf_getUID('jsmith119');" aria-label="Show more information about Smith,&nbsp;Jackson">Smith,&nbsp;Jackson</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith76" data-uid="jsmith76"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith76?s=small" alt="Avatar for Jamison Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith76" onclick="return pf_getUID('jsmith76');" aria-label="Show more information about Smith,&nbsp;Jamison">Smith,&nbsp;Jamison</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith109" data-uid="jsmith109"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith109?s=small" alt="Avatar for Jasmine Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith109" onclick="return pf_getUID('jsmith109');" aria-label="Show more information about Smith,&nbsp;Jasmine">Smith,&nbsp;Jasmine</a></div><div class="tel"><a href="tel:402/8890829">
-402/8890829</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith68" data-uid="jsmith68"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith68?s=small" alt="Avatar for Jay Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith68" onclick="return pf_getUID('jsmith68');" aria-label="Show more information about Smith,&nbsp;Jay">Smith,&nbsp;Jay</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith110" data-uid="jsmith110"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith110?s=small" alt="Avatar for Jayce Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith110" onclick="return pf_getUID('jsmith110');" aria-label="Show more information about Smith,&nbsp;Jayce">Smith,&nbsp;Jayce</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith94" data-uid="jsmith94"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith94?s=small" alt="Avatar for Jennifer Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith94" onclick="return pf_getUID('jsmith94');" aria-label="Show more information about Smith,&nbsp;Jennifer">Smith,&nbsp;Jennifer</a></div><div class="tel"><a href="tel:970/9465618">
-970/9465618</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith129" data-uid="jsmith129"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith129?s=small" alt="Avatar for Jennifer Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith129" onclick="return pf_getUID('jsmith129');" aria-label="Show more information about Smith,&nbsp;Jennifer">Smith,&nbsp;Jennifer</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith112" data-uid="jsmith112"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith112?s=small" alt="Avatar for Jessi Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith112" onclick="return pf_getUID('jsmith112');" aria-label="Show more information about Smith,&nbsp;Jessi">Smith,&nbsp;Jessi</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith114" data-uid="jsmith114"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith114?s=small" alt="Avatar for Jessica Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith114" onclick="return pf_getUID('jsmith114');" aria-label="Show more information about Smith,&nbsp;Jessica">Smith,&nbsp;Jessica</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Office of Information Technology Services</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024720933">
-402-472-0933</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024720933"><span class="on-campus-label">On-campus </span>2-0933</abbr></div></div></div></li><li class="ppl_Sresult volunteer" data-href="https://directory.unl.edu/people/jschiltmeyer2" data-uid="jschiltmeyer2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jschiltmeyer2?s=small" alt="Avatar for Jill Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jschiltmeyer2" onclick="return pf_getUID('jschiltmeyer2');" aria-label="Show more information about Smith,&nbsp;Jill">Smith,&nbsp;Jill</a></div><div class="tel"><a href="tel:4024721368">
-402-472-1368</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721368"><span class="on-campus-label">On-campus </span>2-1368</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith113" data-uid="jsmith113"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith113?s=small" alt="Avatar for Jocelyn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith113" onclick="return pf_getUID('jsmith113');" aria-label="Show more information about Smith,&nbsp;Jocelyn">Smith,&nbsp;Jocelyn</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith104" data-uid="jsmith104"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith104?s=small" alt="Avatar for JoEllen Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith104" onclick="return pf_getUID('jsmith104');" aria-label="Show more information about Smith,&nbsp;JoEllen">Smith,&nbsp;JoEllen</a></div><div class="tel"><a href="tel:402/7338592">
-402/7338592</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith98" data-uid="jsmith98"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith98?s=small" alt="Avatar for Jonathan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith98" onclick="return pf_getUID('jsmith98');" aria-label="Show more information about Smith,&nbsp;Jonathan">Smith,&nbsp;Jonathan</a></div><div class="tel"><a href="tel:4024724611">
-402-472-4611</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724611"><span class="on-campus-label">On-campus </span>2-4611</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith78" data-uid="jsmith78"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith78?s=small" alt="Avatar for Joshua Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith78" onclick="return pf_getUID('jsmith78');" aria-label="Show more information about Smith,&nbsp;Joshua">Smith,&nbsp;Joshua</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith55" data-uid="jsmith55"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith55?s=small" alt="Avatar for Julia Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith55" onclick="return pf_getUID('jsmith55');" aria-label="Show more information about Smith,&nbsp;Julia">Smith,&nbsp;Julia</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith22" data-uid="jsmith22"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith22?s=small" alt="Avatar for Julianne Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith22" onclick="return pf_getUID('jsmith22');" aria-label="Show more information about Smith,&nbsp;Julianne">Smith,&nbsp;Julianne</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith76" data-uid="ksmith76"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith76?s=small" alt="Avatar for Kalith Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith76" onclick="return pf_getUID('ksmith76');" aria-label="Show more information about Smith,&nbsp;Kalith">Smith,&nbsp;Kalith</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith107" data-uid="ksmith107"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith107?s=small" alt="Avatar for Kamryn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith107" onclick="return pf_getUID('ksmith107');" aria-label="Show more information about Smith,&nbsp;Kamryn">Smith,&nbsp;Kamryn</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith46" data-uid="ksmith46"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith46?s=small" alt="Avatar for Karalyn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith46" onclick="return pf_getUID('ksmith46');" aria-label="Show more information about Smith,&nbsp;Karalyn">Smith,&nbsp;Karalyn</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Campus Rec-Informal</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Campus Rec-Child Care</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723467">
-402-472-3467</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723467"><span class="on-campus-label">On-campus </span>2-3467</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith78" data-uid="ksmith78"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith78?s=small" alt="Avatar for Kasey Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith78" onclick="return pf_getUID('ksmith78');" aria-label="Show more information about Smith,&nbsp;Kasey">Smith,&nbsp;Kasey</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith94" data-uid="ksmith94"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith94?s=small" alt="Avatar for Katherine Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith94" onclick="return pf_getUID('ksmith94');" aria-label="Show more information about Smith,&nbsp;Katherine">Smith,&nbsp;Katherine</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith100" data-uid="ksmith100"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith100?s=small" alt="Avatar for Kathleen Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith100" onclick="return pf_getUID('ksmith100');" aria-label="Show more information about Smith,&nbsp;Kathleen">Smith,&nbsp;Kathleen</a></div><div class="tel"><a href="tel:402/3265975">
-402/3265975</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith47" data-uid="ksmith47"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith47?s=small" alt="Avatar for Kayla Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith47" onclick="return pf_getUID('ksmith47');" aria-label="Show more information about Smith,&nbsp;Kayla">Smith,&nbsp;Kayla</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Graduate Teaching Asst</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Sociology</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723672">
-402-472-3672</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723672"><span class="on-campus-label">On-campus </span>2-3672</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/klandy2" data-uid="klandy2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/klandy2?s=small" alt="Avatar for Kayleen Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/klandy2" onclick="return pf_getUID('klandy2');" aria-label="Show more information about Smith,&nbsp;Kayleen">Smith,&nbsp;Kayleen</a></div><div class="tel"><a href="tel:4024722009">
-402-472-2009</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722009"><span class="on-campus-label">On-campus </span>2-2009</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith77" data-uid="ksmith77"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith77?s=small" alt="Avatar for Keegan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith77" onclick="return pf_getUID('ksmith77');" aria-label="Show more information about Smith,&nbsp;Keegan">Smith,&nbsp;Keegan</a></div><div class="title" itemprop="jobTitle">Student Worker</div><div class="tel"><a href="tel:4024720698">
-402-472-0698</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024720698"><span class="on-campus-label">On-campus </span>2-0698</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith83" data-uid="ksmith83"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith83?s=small" alt="Avatar for Kelly Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith83" onclick="return pf_getUID('ksmith83');" aria-label="Show more information about Smith,&nbsp;Kelly">Smith,&nbsp;Kelly</a></div><div class="tel"><a href="tel:4024721884">
-402-472-1884</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721884"><span class="on-campus-label">On-campus </span>2-1884</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/ksmith2" data-uid="ksmith2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith2?s=small" alt="Avatar for Kelly Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith2" onclick="return pf_getUID('ksmith2');" aria-label="Show more information about Smith,&nbsp;Kelly">Smith,&nbsp;Kelly</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Specialist Drought Resources</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">School of Natural Resources</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723373">
-402-472-3373</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723373"><span class="on-campus-label">On-campus </span>2-3373</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith64" data-uid="ksmith64"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith64?s=small" alt="Avatar for Kelly Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith64" onclick="return pf_getUID('ksmith64');" aria-label="Show more information about Smith,&nbsp;Kelly">Smith,&nbsp;Kelly</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Office of Admissions</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722023">
-402-472-2023</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722023"><span class="on-campus-label">On-campus </span>2-2023</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith52" data-uid="ksmith52"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith52?s=small" alt="Avatar for Kenna Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith52" onclick="return pf_getUID('ksmith52');" aria-label="Show more information about Smith,&nbsp;Kenna">Smith,&nbsp;Kenna</a></div><div class="tel"><a href="tel:4024722072">
-402-472-2072</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722072"><span class="on-campus-label">On-campus </span>2-2072</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith82" data-uid="ksmith82"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith82?s=small" alt="Avatar for Kevin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith82" onclick="return pf_getUID('ksmith82');" aria-label="Show more information about Smith,&nbsp;Kevin">Smith,&nbsp;Kevin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith89" data-uid="ksmith89"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith89?s=small" alt="Avatar for Kirk Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith89" onclick="return pf_getUID('ksmith89');" aria-label="Show more information about Smith,&nbsp;Kirk">Smith,&nbsp;Kirk</a></div></div></div></li><li class="ppl_Sresult faculty" data-href="https://directory.unl.edu/people/ksmith9" data-uid="ksmith9"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith9?s=small" alt="Avatar for Kirsten Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith9" onclick="return pf_getUID('ksmith9');" aria-label="Show more information about Smith,&nbsp;Kirsten">Smith,&nbsp;Kirsten</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Lecturer/T</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Center for Science, Mathematics &amp; Computer Education</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024728965">
-402-472-8965</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728965"><span class="on-campus-label">On-campus </span>2-8965</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith63" data-uid="ksmith63"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith63?s=small" alt="Avatar for Kole Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith63" onclick="return pf_getUID('ksmith63');" aria-label="Show more information about Smith,&nbsp;Kole">Smith,&nbsp;Kole</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nebraska Unions</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker #2</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Nebraska Unions</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722181">
-402-472-2181</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722181"><span class="on-campus-label">On-campus </span>2-2181</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith90" data-uid="ksmith90"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith90?s=small" alt="Avatar for Kurtis Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith90" onclick="return pf_getUID('ksmith90');" aria-label="Show more information about Smith,&nbsp;Kurtis">Smith,&nbsp;Kurtis</a></div><div class="tel"><a href="tel:4024725522">
-402-472-5522</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725522"><span class="on-campus-label">On-campus </span>2-5522</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ksmith53" data-uid="ksmith53"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ksmith53?s=small" alt="Avatar for Kyle Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ksmith53" onclick="return pf_getUID('ksmith53');" aria-label="Show more information about Smith,&nbsp;Kyle">Smith,&nbsp;Kyle</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/lsmith46" data-uid="lsmith46"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/lsmith46?s=small" alt="Avatar for Lauren Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/lsmith46" onclick="return pf_getUID('lsmith46');" aria-label="Show more information about Smith,&nbsp;Lauren">Smith,&nbsp;Lauren</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/lsmith55" data-uid="lsmith55"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/lsmith55?s=small" alt="Avatar for Lauryn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/lsmith55" onclick="return pf_getUID('lsmith55');" aria-label="Show more information about Smith,&nbsp;Lauryn">Smith,&nbsp;Lauryn</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/lsmith50" data-uid="lsmith50"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/lsmith50?s=small" alt="Avatar for Leanna Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/lsmith50" onclick="return pf_getUID('lsmith50');" aria-label="Show more information about Smith,&nbsp;Leanna">Smith,&nbsp;Leanna</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/lnguyen33" data-uid="lnguyen33"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/lnguyen33?s=small" alt="Avatar for Leslie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/lnguyen33" onclick="return pf_getUID('lnguyen33');" aria-label="Show more information about Smith,&nbsp;Leslie">Smith,&nbsp;Leslie</a></div><div class="tel"><a href="tel:281/7340313">
-281/7340313</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/lsmith28" data-uid="lsmith28"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/lsmith28?s=small" alt="Avatar for Louis Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/lsmith28" onclick="return pf_getUID('lsmith28');" aria-label="Show more information about Smith,&nbsp;Louis">Smith,&nbsp;Louis</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/lsmith51" data-uid="lsmith51"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/lsmith51?s=small" alt="Avatar for Lucas Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/lsmith51" onclick="return pf_getUID('lsmith51');" aria-label="Show more information about Smith,&nbsp;Lucas">Smith,&nbsp;Lucas</a></div><div class="tel"><a href="tel:402/9807782">
-402/9807782</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/esmith36" data-uid="esmith36"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/esmith36?s=small" alt="Avatar for Lyzz Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/esmith36" onclick="return pf_getUID('esmith36');" aria-label="Show more information about Smith,&nbsp;Lyzz">Smith,&nbsp;Lyzz</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith65" data-uid="msmith65"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith65?s=small" alt="Avatar for Maddi Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith65" onclick="return pf_getUID('msmith65');" aria-label="Show more information about Smith,&nbsp;Maddi">Smith,&nbsp;Maddi</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/s-msmit102" data-uid="s-msmit102"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-msmit102?s=small" alt="Avatar for Madeline Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-msmit102" onclick="return pf_getUID('s-msmit102');" aria-label="Show more information about Smith,&nbsp;Madeline">Smith,&nbsp;Madeline</a></div><div class="tel"><a href="tel:4024727345">
-402-472-7345</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024727345"><span class="on-campus-label">On-campus </span>2-7345</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith60" data-uid="msmith60"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith60?s=small" alt="Avatar for Madison Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith60" onclick="return pf_getUID('msmith60');" aria-label="Show more information about Smith,&nbsp;Madison">Smith,&nbsp;Madison</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith54" data-uid="msmith54"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith54?s=small" alt="Avatar for Madison Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith54" onclick="return pf_getUID('msmith54');" aria-label="Show more information about Smith,&nbsp;Madison">Smith,&nbsp;Madison</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith67" data-uid="msmith67"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith67?s=small" alt="Avatar for Makenzie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith67" onclick="return pf_getUID('msmith67');" aria-label="Show more information about Smith,&nbsp;Makenzie">Smith,&nbsp;Makenzie</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Child Care</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722009">
-402-472-2009</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722009"><span class="on-campus-label">On-campus </span>2-2009</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith72" data-uid="msmith72"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith72?s=small" alt="Avatar for Matthew Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith72" onclick="return pf_getUID('msmith72');" aria-label="Show more information about Smith,&nbsp;Matthew">Smith,&nbsp;Matthew</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith56" data-uid="msmith56"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith56?s=small" alt="Avatar for Matthew Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith56" onclick="return pf_getUID('msmith56');" aria-label="Show more information about Smith,&nbsp;Matthew">Smith,&nbsp;Matthew</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith59" data-uid="msmith59"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith59?s=small" alt="Avatar for Matthew Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith59" onclick="return pf_getUID('msmith59');" aria-label="Show more information about Smith,&nbsp;Matthew">Smith,&nbsp;Matthew</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith75" data-uid="msmith75"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith75?s=small" alt="Avatar for McKay Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith75" onclick="return pf_getUID('msmith75');" aria-label="Show more information about Smith,&nbsp;McKay">Smith,&nbsp;McKay</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith71" data-uid="msmith71"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith71?s=small" alt="Avatar for Megan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith71" onclick="return pf_getUID('msmith71');" aria-label="Show more information about Smith,&nbsp;Megan">Smith,&nbsp;Megan</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith76" data-uid="msmith76"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith76?s=small" alt="Avatar for Michaela Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith76" onclick="return pf_getUID('msmith76');" aria-label="Show more information about Smith,&nbsp;Michaela">Smith,&nbsp;Michaela</a></div><div class="tel"><a href="tel:402/4010106">
-402/4010106</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith63" data-uid="msmith63"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith63?s=small" alt="Avatar for Mondale Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith63" onclick="return pf_getUID('msmith63');" aria-label="Show more information about Smith,&nbsp;Mondale">Smith,&nbsp;Mondale</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/msmith36" data-uid="msmith36"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/msmith36?s=small" alt="Avatar for Morgan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/msmith36" onclick="return pf_getUID('msmith36');" aria-label="Show more information about Smith,&nbsp;Morgan">Smith,&nbsp;Morgan</a></div><div class="tel"><a href="tel:3083909347">
-308-390-9347</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/nsmith9" data-uid="nsmith9"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith9?s=small" alt="Avatar for Nathaniel Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith9" onclick="return pf_getUID('nsmith9');" aria-label="Show more information about Smith,&nbsp;Nathaniel">Smith,&nbsp;Nathaniel</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/nsmith26" data-uid="nsmith26"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith26?s=small" alt="Avatar for Neland Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith26" onclick="return pf_getUID('nsmith26');" aria-label="Show more information about Smith,&nbsp;Neland">Smith,&nbsp;Neland</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/nsmith24" data-uid="nsmith24"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith24?s=small" alt="Avatar for Nevada Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith24" onclick="return pf_getUID('nsmith24');" aria-label="Show more information about Smith,&nbsp;Nevada">Smith,&nbsp;Nevada</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/nsmith27" data-uid="nsmith27"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith27?s=small" alt="Avatar for Nicholas Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith27" onclick="return pf_getUID('nsmith27');" aria-label="Show more information about Smith,&nbsp;Nicholas">Smith,&nbsp;Nicholas</a></div><div class="tel"><a href="tel:4024723116">
-402-472-3116</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723116"><span class="on-campus-label">On-campus </span>2-3116</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/nsmith20" data-uid="nsmith20"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith20?s=small" alt="Avatar for Nicole Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith20" onclick="return pf_getUID('nsmith20');" aria-label="Show more information about Smith,&nbsp;Nicole">Smith,&nbsp;Nicole</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Earth &amp; Atmospheric Sciences</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722663">
-402-472-2663</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722663"><span class="on-campus-label">On-campus </span>2-2663</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/nsmith7" data-uid="nsmith7"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith7?s=small" alt="Avatar for Nicole Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith7" onclick="return pf_getUID('nsmith7');" aria-label="Show more information about Smith,&nbsp;Nicole">Smith,&nbsp;Nicole</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Development Coord</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Agricultural Sciences and Natural Resources</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024720609">
-402-472-0609</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024720609"><span class="on-campus-label">On-campus </span>2-0609</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/nsmith28" data-uid="nsmith28"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/nsmith28?s=small" alt="Avatar for Noele Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/nsmith28" onclick="return pf_getUID('nsmith28');" aria-label="Show more information about Smith,&nbsp;Noele">Smith,&nbsp;Noele</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/psmith35" data-uid="psmith35"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/psmith35?s=small" alt="Avatar for Patrick Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/psmith35" onclick="return pf_getUID('psmith35');" aria-label="Show more information about Smith,&nbsp;Patrick">Smith,&nbsp;Patrick</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Graduate Teaching Asst</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">College of Business</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024729013">
-402-472-9013</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024729013"><span class="on-campus-label">On-campus </span>2-9013</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/s-psmith16" data-uid="s-psmith16"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/s-psmith16?s=small" alt="Avatar for Paul Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/s-psmith16" onclick="return pf_getUID('s-psmith16');" aria-label="Show more information about Smith,&nbsp;Paul">Smith,&nbsp;Paul</a></div><div class="tel"><a href="tel:4024727539">
-402-472-7539</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024727539"><span class="on-campus-label">On-campus </span>2-7539</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/psmith33" data-uid="psmith33"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/psmith33?s=small" alt="Avatar for Paxton Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/psmith33" onclick="return pf_getUID('psmith33');" aria-label="Show more information about Smith,&nbsp;Paxton">Smith,&nbsp;Paxton</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/psmith28" data-uid="psmith28"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/psmith28?s=small" alt="Avatar for Presley Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/psmith28" onclick="return pf_getUID('psmith28');" aria-label="Show more information about Smith,&nbsp;Presley">Smith,&nbsp;Presley</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Campus Rec-Fitness/Wellness</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Work/Study Student</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">HSS Residence Life</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li><li class="org parent-unl"><span class="title" itemprop="jobTitle">Work/Study Student</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">HSS Residence Life</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723467">
-402-472-3467</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723467"><span class="on-campus-label">On-campus </span>2-3467</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith56" data-uid="rsmith56"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith56?s=small" alt="Avatar for Rachel Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith56" onclick="return pf_getUID('rsmith56');" aria-label="Show more information about Smith,&nbsp;Rachel">Smith,&nbsp;Rachel</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Graduate Teaching Asst</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Educational Psychology</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722223">
-402-472-2223</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722223"><span class="on-campus-label">On-campus </span>2-2223</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith70" data-uid="rsmith70"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith70?s=small" alt="Avatar for Rachel Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith70" onclick="return pf_getUID('rsmith70');" aria-label="Show more information about Smith,&nbsp;Rachel">Smith,&nbsp;Rachel</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith57" data-uid="rsmith57"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith57?s=small" alt="Avatar for Rebecca Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith57" onclick="return pf_getUID('rsmith57');" aria-label="Show more information about Smith,&nbsp;Rebecca">Smith,&nbsp;Rebecca</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith45" data-uid="rsmith45"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith45?s=small" alt="Avatar for Regen Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith45" onclick="return pf_getUID('rsmith45');" aria-label="Show more information about Smith,&nbsp;Regen">Smith,&nbsp;Regen</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Housing Residence Life</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024721066">
-402-472-1066</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721066"><span class="on-campus-label">On-campus </span>2-1066</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith72" data-uid="rsmith72"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith72?s=small" alt="Avatar for Rhyse Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith72" onclick="return pf_getUID('rsmith72');" aria-label="Show more information about Smith,&nbsp;Rhyse">Smith,&nbsp;Rhyse</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith46" data-uid="rsmith46"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith46?s=small" alt="Avatar for Riley Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith46" onclick="return pf_getUID('rsmith46');" aria-label="Show more information about Smith,&nbsp;Riley">Smith,&nbsp;Riley</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith71" data-uid="rsmith71"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith71?s=small" alt="Avatar for Robyn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith71" onclick="return pf_getUID('rsmith71');" aria-label="Show more information about Smith,&nbsp;Robyn">Smith,&nbsp;Robyn</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Athletics</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024724611">
-402-472-4611</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724611"><span class="on-campus-label">On-campus </span>2-4611</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith13" data-uid="rsmith13"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith13?s=small" alt="Avatar for Ryan Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith13" onclick="return pf_getUID('rsmith13');" aria-label="Show more information about Smith,&nbsp;Ryan">Smith,&nbsp;Ryan</a></div><div class="tel"><a href="tel:4024722526">
-402-472-2526</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722526"><span class="on-campus-label">On-campus </span>2-2526</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/rsmith55" data-uid="rsmith55"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/rsmith55?s=small" alt="Avatar for Rylee Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/rsmith55" onclick="return pf_getUID('rsmith55');" aria-label="Show more information about Smith,&nbsp;Rylee">Smith,&nbsp;Rylee</a></div><div class="tel"><a href="tel:4024722181">
-402-472-2181</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722181"><span class="on-campus-label">On-campus </span>2-2181</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith126" data-uid="ssmith126"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith126?s=small" alt="Avatar for Samantha Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith126" onclick="return pf_getUID('ssmith126');" aria-label="Show more information about Smith,&nbsp;Samantha">Smith,&nbsp;Samantha</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith146" data-uid="ssmith146"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith146?s=small" alt="Avatar for Samantha Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith146" onclick="return pf_getUID('ssmith146');" aria-label="Show more information about Smith,&nbsp;Samantha">Smith,&nbsp;Samantha</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith142" data-uid="ssmith142"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith142?s=small" alt="Avatar for Samuel Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith142" onclick="return pf_getUID('ssmith142');" aria-label="Show more information about Smith,&nbsp;Samuel">Smith,&nbsp;Samuel</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith106" data-uid="ssmith106"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith106?s=small" alt="Avatar for Sarah Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith106" onclick="return pf_getUID('ssmith106');" aria-label="Show more information about Smith,&nbsp;Sarah">Smith,&nbsp;Sarah</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Student Worker</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">New Student Enrollment</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024724646">
-402-472-4646</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724646"><span class="on-campus-label">On-campus </span>2-4646</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith97" data-uid="ssmith97"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith97?s=small" alt="Avatar for Savannah Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith97" onclick="return pf_getUID('ssmith97');" aria-label="Show more information about Smith,&nbsp;Savannah">Smith,&nbsp;Savannah</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith89" data-uid="ssmith89"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith89?s=small" alt="Avatar for Scott Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith89" onclick="return pf_getUID('ssmith89');" aria-label="Show more information about Smith,&nbsp;Scott">Smith,&nbsp;Scott</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith139" data-uid="ssmith139"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith139?s=small" alt="Avatar for Sophie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith139" onclick="return pf_getUID('ssmith139');" aria-label="Show more information about Smith,&nbsp;Sophie">Smith,&nbsp;Sophie</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Work/Study Student</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Campus Rec-EC Activity Bldg</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024723467">
-402-472-3467</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723467"><span class="on-campus-label">On-campus </span>2-3467</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith42" data-uid="ssmith42"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith42?s=small" alt="Avatar for Steven Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith42" onclick="return pf_getUID('ssmith42');" aria-label="Show more information about Smith,&nbsp;Steven">Smith,&nbsp;Steven</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith141" data-uid="ssmith141"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith141?s=small" alt="Avatar for Sydnie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith141" onclick="return pf_getUID('ssmith141');" aria-label="Show more information about Smith,&nbsp;Sydnie">Smith,&nbsp;Sydnie</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/tsmith42" data-uid="tsmith42"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith42?s=small" alt="Avatar for Tanner Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith42" onclick="return pf_getUID('tsmith42');" aria-label="Show more information about Smith,&nbsp;Tanner">Smith,&nbsp;Tanner</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/tsmith38" data-uid="tsmith38"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith38?s=small" alt="Avatar for Taryn Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith38" onclick="return pf_getUID('tsmith38');" aria-label="Show more information about Smith,&nbsp;Taryn">Smith,&nbsp;Taryn</a></div><div class="tel"><a href="tel:4024723225">
-402-472-3225</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024723225"><span class="on-campus-label">On-campus </span>2-3225</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/tsmith57" data-uid="tsmith57"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith57?s=small" alt="Avatar for Timothy Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith57" onclick="return pf_getUID('tsmith57');" aria-label="Show more information about Smith,&nbsp;Timothy">Smith,&nbsp;Timothy</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/tsmith50" data-uid="tsmith50"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith50?s=small" alt="Avatar for Torin Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith50" onclick="return pf_getUID('tsmith50');" aria-label="Show more information about Smith,&nbsp;Torin">Smith,&nbsp;Torin</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/tsmith53" data-uid="tsmith53"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith53?s=small" alt="Avatar for Travis Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith53" onclick="return pf_getUID('tsmith53');" aria-label="Show more information about Smith,&nbsp;Travis">Smith,&nbsp;Travis</a></div><div class="tel"><a href="tel:4024725866">
-402-472-5866</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725866"><span class="on-campus-label">On-campus </span>2-5866</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/tsmith48" data-uid="tsmith48"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith48?s=small" alt="Avatar for Trevor Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith48" onclick="return pf_getUID('tsmith48');" aria-label="Show more information about Smith,&nbsp;Trevor">Smith,&nbsp;Trevor</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/tsmith21" data-uid="tsmith21"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/tsmith21?s=small" alt="Avatar for Tyler Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/tsmith21" onclick="return pf_getUID('tsmith21');" aria-label="Show more information about Smith,&nbsp;Tyler">Smith,&nbsp;Tyler</a></div><div class="tel"><a href="tel:4024724078">
-402-472-4078</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024724078"><span class="on-campus-label">On-campus </span>2-4078</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/vsmith8" data-uid="vsmith8"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/vsmith8?s=small" alt="Avatar for Vivian Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/vsmith8" onclick="return pf_getUID('vsmith8');" aria-label="Show more information about Smith,&nbsp;Vivian">Smith,&nbsp;Vivian</a></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/wsmith10" data-uid="wsmith10"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/wsmith10?s=small" alt="Avatar for Weldon Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/wsmith10" onclick="return pf_getUID('wsmith10');" aria-label="Show more information about Smith,&nbsp;Weldon">Smith,&nbsp;Weldon</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Graduate Research Asst</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Buros Center for Testing</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722580">
-402-472-2580</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722580"><span class="on-campus-label">On-campus </span>2-2580</abbr></div></div></div></li><li class="ppl_Sresult staff" data-href="https://directory.unl.edu/people/zsmith7" data-uid="zsmith7"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/zsmith7?s=small" alt="Avatar for Zachary Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/zsmith7" onclick="return pf_getUID('zsmith7');" aria-label="Show more information about Smith,&nbsp;Zachary">Smith,&nbsp;Zachary</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">M/P Temporary Worker Hourly</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Physics &amp; Astronomy</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722770">
-402-472-2770</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722770"><span class="on-campus-label">On-campus </span>2-2770</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/ssmith-eskridge2" data-uid="ssmith-eskridge2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith-eskridge2?s=small" alt="Avatar for Samuel Smith-Eskridge"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith-eskridge2" onclick="return pf_getUID('ssmith-eskridge2');" aria-label="Show more information about Smith-Eskridge,&nbsp;Samuel">Smith-Eskridge,&nbsp;Samuel</a></div><div class="tel"><a href="tel:4024725190">
-402-472-5190</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024725190"><span class="on-campus-label">On-campus </span>2-5190</abbr></div></div></div></li><li class="ppl_Sresult student" data-href="https://directory.unl.edu/people/jsmith-wilson2" data-uid="jsmith-wilson2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jsmith-wilson2?s=small" alt="Avatar for Johnny Smith-Wilson"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jsmith-wilson2" onclick="return pf_getUID('jsmith-wilson2');" aria-label="Show more information about Smith-Wilson,&nbsp;Johnny">Smith-Wilson,&nbsp;Johnny</a></div></div></div></li></ul></div>
-
-
-
-<div id="results_volunteer" class="results affiliation volunteer" style="display: block;"><h2 class="wdn-brand">Volunteer</h2><div class="result_head">6 results found</div><ul class="pfResult"><li class="ppl_Sresult volunteer" data-href="https://directory.unl.edu/people/asmith76" data-uid="asmith76"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/asmith76?s=small" alt="Avatar for Alice Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/asmith76" onclick="return pf_getUID('asmith76');" aria-label="Show more information about Smith,&nbsp;Alice">Smith,&nbsp;Alice</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Project Contact</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Southeast Research &amp; Extension Center</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4026417986">
-402-641-7986</a></div></div></div></li><li class="ppl_Sresult volunteer" data-href="https://directory.unl.edu/people/dsmith45" data-uid="dsmith45"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith45?s=small" alt="Avatar for Darold Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith45" onclick="return pf_getUID('dsmith45');" aria-label="Show more information about Smith,&nbsp;Darold">Smith,&nbsp;Darold</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Volunteer</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Biological Systems Engineering</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024728389">
-402-472-8389</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024728389"><span class="on-campus-label">On-campus </span>2-8389</abbr></div></div></div></li><li class="ppl_Sresult volunteer" data-href="https://directory.unl.edu/people/dsmith35" data-uid="dsmith35"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/dsmith35?s=small" alt="Avatar for Doris Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/dsmith35" onclick="return pf_getUID('dsmith35');" aria-label="Show more information about Smith,&nbsp;Doris">Smith,&nbsp;Doris</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Retiree</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">Retirees</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:4024722600">
-402-472-2600</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024722600"><span class="on-campus-label">On-campus </span>2-2600</abbr></div></div></div></li><li class="ppl_Sresult volunteer" data-href="https://directory.unl.edu/people/jschiltmeyer2" data-uid="jschiltmeyer2"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/jschiltmeyer2?s=small" alt="Avatar for Jill Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/jschiltmeyer2" onclick="return pf_getUID('jschiltmeyer2');" aria-label="Show more information about Smith,&nbsp;Jill">Smith,&nbsp;Jill</a></div><div class="tel"><a href="tel:4024721368">
-402-472-1368</a>
-<abbr class="on-campus-dialing" title="For on-campus dialing only. Off-campus, dial 4024721368"><span class="on-campus-label">On-campus </span>2-1368</abbr></div></div></div></li><li class="ppl_Sresult volunteer" data-href="https://directory.unl.edu/people/psmith3" data-uid="psmith3"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/psmith3?s=small" alt="Avatar for Peggy Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/psmith3" onclick="return pf_getUID('psmith3');" aria-label="Show more information about Smith,&nbsp;Peggy">Smith,&nbsp;Peggy</a></div><ul class="roles"><li class="org parent-unl"><span class="title" itemprop="jobTitle">Office Support</span>
-<span itemprop="worksFor" itemscope="" itemtype="http://schema.org/Organization">
-<span class="organization-unit">
-<span itemprop="name">West Central Research &amp; Extension Center</span>
-</span>
-<span class="organization-name" itemprop="parentOrganization" itemscope="" itemtype="http://schema.org/Organization"><span itemprop="name">University of Nebraska–Lincoln</span></span>
-</span></li></ul><div class="tel"><a href="tel:3083674424">
-308-367-4424</a></div></div></div></li><li class="ppl_Sresult volunteer" data-href="https://directory.unl.edu/people/ssmith67" data-uid="ssmith67"><div class="overflow" itemscope="" itemtype="http://schema.org/Person"><div class="profile_pic"><img class="photo" itemprop="image" src="https://directory.unl.edu/avatar/ssmith67?s=small" alt="Avatar for Stephanie Smith"></div><div class="recordDetails"><div class="fn" itemprop="name"><a itemprop="url" href="https://directory.unl.edu/people/ssmith67" onclick="return pf_getUID('ssmith67');" aria-label="Show more information about Smith,&nbsp;Stephanie">Smith,&nbsp;Stephanie</a></div><div class="tel"><a href="tel:4025591843">
-402-559-1843</a></div></div></div></li></ul></div></div>
--->
 
           <button style="top:1%;right:1%;" class="dcf-u-absolute" type="button" aria-label="close">Close</button>
 

--- a/wdn/templates_5.0/scss/components/_components.search.scss
+++ b/wdn/templates_5.0/scss/components/_components.search.scss
@@ -3,6 +3,17 @@
 ///////////////////////////////
 
 
+.unl-google-results {
+  @include mb8;
+}
+
+.unl-c-directory-result:not(:last-child) {
+  @include mb6;
+}
+
+.unl-c-directory-result:last-child {
+  @include mb0;
+}
 
 @include mq(md, min, width) {
 
@@ -27,136 +38,152 @@
   font-size: inherit;
 }
 
+.unl .gsc-above-wrapper-area {
+  @include mb7;
+  @include p0;
+  @include b0;
+}
+
+.unl .gsc-result-info {
+  @include m0;
+  @include p0;
+  font-size: inherit;
+  color: $color-body;
+}
+
+.unl .gcsc-branding {
+  @include none;
+}
+
+.unl .gsc-webResult .gsc-result {
+  @include pt0;
+  @include pb6;
+  @include b0;
+}
+
 .unl .gsc-thumbnail-inside {
-//     padding-left: 0;
-//     padding-right: 0;
-  @include pr0;
-  @include pl0;
+  @include none;
+}
+
+.unl .gsc-thumbnail-left {
+  @include mb1;
+}
+
+.unl .gs-snippet {
+  @include mt1;
+  @include mb1;
+}
+
+.gsc-control-cse .gs-result .gsc-table-cell-snippet-close > .gs-title {
+  @include h5;
+}
+
+.gsc-control-cse .gs-result .gsc-table-cell-snippet-close > .gs-title * {
+  font-size: 1em;
+}
+
+.unl .gsc-url-top {
+  @include none;
 }
 
 .unl .gsc-control-cse .gs-snippet {
   color: inherit;
 }
 
-.unl .gsc-thumbnail .gs-image-box {
-//     padding-right: 0.5em;
-  @include pr4;
+.unl .gsc-thumbnail {
+  @include pt1;
+  @include pr5;
 }
 
-.unl .gsc-url-top {
-  font-size: 80%;
-//     padding-left: 0;
-//     padding-right: 0;
-  @include pr0;
-  @include pl0;
-}
-
-.unl .gsc-control-cse {
-//     padding: 0;
+.unl .gs-web-image-box,
+.unl .gs-promotion-image-box {
   @include p0;
-}
-
-.unl .gsc-webResult .gsc-result {
-  padding: 0.75em 0;
-//     border: 0;
-  @include b0;
-}
-
-.unl .gsc-result .gs-title {
-  height: 1.662em;
-}
-
-.unl .gsc-result.gsc-webResult:hover {
-//     border: none;
-  @include b0;
-}
-
-.unl .gs-result .gs-title,
-.unl .gs-result .gs-title * {
-//     color: #d00000;
-//     text-decoration: none;
-  color: $scarlet;
-  @include txt-decor-none;
-}
-
-.unl .gs-result .gs-visibleUrl,
-.unl .gs-result .gsc-url-top,
-.unl .gs-result a.gs-visibleUrl {
-    color: #554721;
-}
-
-.unl .gsc-result-info {
-//     font-style: italic;
-  @include italic;
-  margin: 0 0 10px;
-//     color: #5b5b5a;
-  color: $color-body;
-}
-
-.unl .gsc-results .gsc-cursor-box {
-  border-top: 1px solid #eae9e6;
-//     padding: 1em 0 0;
-  @include pt4;
-  @include pr0;
-  @include pb0;
-  @include pl0;
-//     margin-top: 1em;
-    @include mt4;
-//     font-family: "Gotham SSm A","Gotham SSm B",Verdana,"Verdana Ref",Geneva,Tahoma,"Lucida Grande","Lucida Sans Unicode","Lucida Sans","DejaVu Sans","Bitstream Vera Sans","Liberation Sans",sans-serif;
-//     font-weight: 400;
-//     font-style: normal;
-}
-
-.unl .gsc-results .gsc-cursor-box .gsc-cursor-page {
-  border: 1px solid #eae9e6;
-  padding: 2px 8px;
-//     margin-bottom: 1em;
-  @include mb4;
-    min-width: 2.2em;
-//     display: inline-block;
-  @include inlineblock;
-//     text-align: center;
-  @include txt-center;
-//     text-decoration: none;
-  @include txt-decor-none;
-//     color: #d00000;
-  color: $scarlet;
-}
-
-.unl .gsc-results .gsc-cursor-box .gsc-cursor-current-page {
-  font-weight: 400;
-//     color: #5b5b5a;
-  color: $color-body;
-//     border: 0;
-  @include b0;
-}
-
-.unl .gcsc-branding {
-  margin-bottom: 1.3333em;
-//     display: none;
-  @include none;
-}
-
-.unl td.gcsc-branding-text {
-//     font-style: italic;
-  width: auto;
-  @include italic;
-}
-
-.unl td.gcsc-branding-text div.gcsc-branding-text {
-//     text-align: left;
-  @include txt-left;
-//     color: #5b5b5a;
-  color: $color-body;
-}
-
-.unl td.gcsc-branding-text-name {
-//     width: 100%;
-  @include w100;
 }
 
 .unl .gs-promotion-image-box img.gs-promotion-image,
 .unl .gs-web-image-box img.gs-image {
   max-width: 100%;
   max-height: none;
+}
+
+.unl .gs-image-box.gs-web-image-box.gs-web-image-box-landscape,
+.unl .gs-image-box.gs-web-image-box.gs-web-image-box-portrait {
+  width: #{ms(10)}rem;
+}
+
+.unl .gs-image-box.gs-web-image-box.gs-web-image-box-portrait {
+  height: auto;
+}
+
+.unl .gs-result img.gs-image,
+.unl .gs-result img.gs-promotion-image {
+  border-color: $color-border;
+}
+
+.unl .gsc-thumbnail-left {
+  @include block;
+}
+
+.unl .gsc-result .gs-title {
+  height: initial;
+}
+
+.unl .gsc-control-cse .gs-spelling,
+.unl .gsc-control-cse .gs-result .gs-title,
+.unl .gsc-control-cse .gs-result .gs-title * {
+  @include lh2;
+}
+
+.unl .gsc-result.gsc-webResult:hover {
+  @include b0;
+}
+
+.unl .gs-result .gs-title,
+.unl .gs-result .gs-title * {
+  color: $scarlet;
+  @include txt-decor-none;
+}
+
+.unl .gsc-url-bottom {
+  @include block;
+  @include sm2;
+}
+
+.unl .gsc-snippet-metadata,
+.unl .gsc-role,
+.unl .gsc-tel,
+.unl .gsc-org,
+.unl .gsc-location,
+.unl .gsc-reviewer,
+.unl .gsc-author,
+.unl .gs-result .gs-visibleUrl,
+.unl .gs-result a.gs-visibleUrl {
+  color: $color-light-text;
+}
+
+.unl .gsc-results .gsc-cursor-box {
+  @include m0;
+  @include pt4;
+  @include pr0;
+  @include pb0;
+  @include pl0;
+  @include bt;
+  border-color: $color-border;
+}
+
+.unl .gsc-results .gsc-cursor-box .gsc-cursor-page {
+  @include inlineblock;
+  @include p1;
+  @include txt-center;
+  color: $scarlet;
+}
+
+.unl .gsc-results .gsc-cursor-box .gsc-cursor-page:not(:last-child) {
+  @include mr4;
+}
+
+.unl .gsc-results .gsc-cursor-box .gsc-cursor-current-page {
+  font-weight: 400;
+  @include txt-decor-none;
+  color: $color-body;
 }


### PR DESCRIPTION
- Update background overlay class for modal overlay
- Namespace Google search results class with ‘unl-‘
- Denote existing 4.1 directory results classes with brackets for later discussion
- Use media object for directory results
- Update utility classes used for layout
- Update Schema.org microdata
- Add '+1' to telephone links
- Remove commented out markup that is no longer needed
- Add margin-bottom to Google search results to prevent vertical collision with UNL directory results when viewed in narrow browser widths
- Add vertical space in between individual directory results with margin-bottom
- Update Google search results style overrides