### PR TITLE
Rename ‘.wdn-icon-container’ class

### DIFF
--- a/wdn/templates_4.1/less/layouts/footer.less
+++ b/wdn/templates_4.1/less/layouts/footer.less
@@ -59,15 +59,15 @@
 		top: -.254em;
 	}
 
-    .wdn-icon-container {
-        position: relative;
-        padding-left: 1.777rem;
+	.wdn-hang-icon {
+		position: relative;
+		padding-left: 1.777rem;
 
-        [class*="wdn-icon-"] {
-          position: absolute;
-          left: 0;
-        }
-    }
+		[class*="wdn-icon-"] {
+			position: absolute;
+			left: 0;
+		}
+	}
 
 	span[role="heading"] {
 		display: block;


### PR DESCRIPTION
WebAudit expects framework icon classes (`.wdn-icon-*`) to contain the `aria-hidden=“true”` attribute for accessibility. However, `.wdn-icon-container` is not an icon itself; instead it can be applied to the parent element of an icon to prevent adjacent text from wrapping below it on a second line, treating icons like hanging indents.