### PR TITLE
Update global footer icon markup

### DIFF
--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -3,14 +3,14 @@
 		<div class="wdn-footer-module wdn-footer-social">
 			<span role="heading">Connect with #UNL</span>
 			<ul class="wdn-footer-list">
-				<li><a href="https://www.facebook.com/UNLincoln" class="wdn-icon-container"><span class="wdn-icon-facebook" aria-hidden="true"></span>UNLincoln <span class="wdn-text-hidden"> on Facebook</span></a></li>
-				<li><a href="https://twitter.com/UNLincoln" class="wdn-icon-container"><span class="wdn-icon-twitter" aria-hidden="true"></span>@UNLincoln<span class="wdn-text-hidden"> on Twitter</span></a></li>
-				<li><a href="https://www.youtube.com/user/unl" class="wdn-icon-container"><span class="wdn-icon-youtube-play" aria-hidden="true"></span>UNL<span class="wdn-text-hidden"> on YouTube</span></a></li>
-				<li><a href="https://www.instagram.com/unlincoln/" class="wdn-icon-container"><span class="wdn-icon-instagram" aria-hidden="true"></span>@unlincoln<span class="wdn-text-hidden"> on Instagram</span></a></li>
-				<li><a href="https://www.linkedin.com/edu/school?id=18836" class="wdn-icon-container"><span class="wdn-icon-linkedin-squared" aria-hidden="true"></span>University of Nebraska&ndash;Lincoln<span class="wdn-text-hidden"> on LinkedIn</span></a></li>
-				<li><a href="https://www.pinterest.com/unlincoln/boards/" class="wdn-icon-container"><span class="wdn-icon-pinterest" aria-hidden="true"></span>unlincoln<span class="wdn-text-hidden"> on Pinterest</span></a></li>
-				<li><a href="snapchat://?u=unlincoln" class="wdn-icon-container"><span class="wdn-icon-snapchat" aria-hidden="true"></span> UNLincoln <span class="wdn-text-hidden"> on Snapchat</span></a></li>
-				<li><a href="https://go.unl.edu/spotify" class="wdn-icon-container"><span class="wdn-icon-spotify" aria-hidden="true"></span>unlincoln<span class="wdn-text-hidden"> on Spotify</span></a></li>
+				<li><a href="https://www.facebook.com/UNLincoln" class="wdn-hang-icon"><span class="wdn-icon-facebook" aria-hidden="true"></span>UNLincoln <span class="wdn-text-hidden"> on Facebook</span></a></li>
+				<li><a href="https://twitter.com/UNLincoln" class="wdn-hang-icon"><span class="wdn-icon-twitter" aria-hidden="true"></span>@UNLincoln<span class="wdn-text-hidden"> on Twitter</span></a></li>
+				<li><a href="https://www.youtube.com/user/unl" class="wdn-hang-icon"><span class="wdn-icon-youtube-play" aria-hidden="true"></span>UNL<span class="wdn-text-hidden"> on YouTube</span></a></li>
+				<li><a href="https://www.instagram.com/unlincoln/" class="wdn-hang-icon"><span class="wdn-icon-instagram" aria-hidden="true"></span>@unlincoln<span class="wdn-text-hidden"> on Instagram</span></a></li>
+				<li><a href="https://www.linkedin.com/edu/school?id=18836" class="wdn-hang-icon"><span class="wdn-icon-linkedin-squared" aria-hidden="true"></span>University of Nebraska&ndash;Lincoln<span class="wdn-text-hidden"> on LinkedIn</span></a></li>
+				<li><a href="https://www.pinterest.com/unlincoln/boards/" class="wdn-hang-icon"><span class="wdn-icon-pinterest" aria-hidden="true"></span>unlincoln<span class="wdn-text-hidden"> on Pinterest</span></a></li>
+				<li><a href="snapchat://?u=unlincoln" class="wdn-hang-icon"><span class="wdn-icon-snapchat" aria-hidden="true"></span> UNLincoln <span class="wdn-text-hidden"> on Snapchat</span></a></li>
+				<li><a href="https://go.unl.edu/spotify" class="wdn-hang-icon"><span class="wdn-icon-spotify" aria-hidden="true"></span>unlincoln<span class="wdn-text-hidden"> on Spotify</span></a></li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
The `.wdn-icon-container` class name was updated to `.wdn-hang-icon` in #1113, but the markup was not also updated to reflect the name change. This fixes that.