### PR TITLE
ensure that a heading level of 2 is used for section headings in the footer

### DIFF
--- a/sharedcode/affiliate/localFooter.html
+++ b/sharedcode/affiliate/localFooter.html
@@ -1,7 +1,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp640-wdn-col-two-thirds bp960-wdn-col-one-half">
 		<div class="wdn-footer-module">
-			<span role="heading">Buros Center for Testing<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading" aria-level="2">Buros Center for Testing<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp960-wdn-grid-set-halves">
 				<div class="wdn-col">
 					<p class="wdn-icon-location">21 Teachers College Hall<br />

--- a/sharedcode/localFooter.html
+++ b/sharedcode/localFooter.html
@@ -2,7 +2,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp640-wdn-col-two-thirds bp960-wdn-col-one-half">
 		<div id="wdn_footer_contact" class="wdn-footer-module">
-			<span role="heading">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading" aria-level="2">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp960-wdn-grid-set-halves">
 				<div class="wdn-col">
 					<dl class="wdn-contact-info">
@@ -46,7 +46,7 @@
 	</div>
 	<div class="wdn-col-full bp640-wdn-col-one-third bp960-wdn-col-one-half">
 		<div id="wdn_footer_related" class="wdn-footer-module">
-			<span role="heading">Related Links</span>
+			<span role="heading" aria-level="2">Related Links</span>
 			<ul class="wdn-related-links-v1">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>
@@ -63,7 +63,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp640-wdn-col-two-thirds bp960-wdn-col-one-half">
 		<div id="wdn_footer_contact" class="wdn-footer-module">
-			<span role="heading">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading" aria-level="2">Hixson-Lied College of Fine and Performing Arts<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp960-wdn-grid-set-halves">
 				<div class="wdn-col">
 					<dl class="wdn-contact-info">
@@ -107,7 +107,7 @@
 	</div>
 	<div class="wdn-col-full bp960-wdn-col-one-half">
 		<div id="wdn_footer_related" class="wdn-footer-module">
-			<span role="heading">Related Links</span>
+			<span role="heading" aria-level="2">Related Links</span>
 			<ul class="wdn-related-links-v2">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>
@@ -135,7 +135,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp960-wdn-col-three-fourths">
 		<div id="wdn_footer_contact" class="wdn-footer-module">
-			<span role="heading">College of Engineering<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading" aria-level="2">College of Engineering<span class="wdn-text-hidden"> Contact Information</span></span>
 			<div class="wdn-grid-set-halves bp640-wdn-grid-set-thirds bp960-wdn-grid-set-thirds">
 				<div class="wdn-col">
 					<dl class="wdn-contact-info">
@@ -187,7 +187,7 @@
 	</div>
 	<div class="wdn-col-full bp960-wdn-col-one-fourth">
 		<div id="wdn_footer_related" class="wdn-footer-module">
-			<span role="heading">Related Links</span>
+			<span role="heading" aria-level="2">Related Links</span>
 			<ul class="wdn-related-links-v3">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>
@@ -209,7 +209,7 @@
 <div class="wdn-grid-set wdn-footer-links-local">
 	<div class="wdn-col-full bp960-wdn-col-one-half">
 		<div id="wdn_footer_contact" class="wdn-footer-module">
-			<span role="heading">University of Nebraska&ndash;Lincoln<span class="wdn-text-hidden"> Contact Information</span></span>
+			<span role="heading" aria-level="2">University of Nebraska&ndash;Lincoln<span class="wdn-text-hidden"> Contact Information</span></span>
 			<p class="wdn-icon-location">1400 'R' Street<br />
 			Lincoln, NE 68588</p>
 			<p class="wdn-icon-phone"><a href="tel:4024727211">402-472-7211</a></p>
@@ -217,7 +217,7 @@
 	</div>
 	<div class="wdn-col-full bp960-wdn-col-one-half">
 		<div id="wdn_footer_related" class="wdn-footer-module">
-			<span role="heading">Related Links</span>
+			<span role="heading" aria-level="2">Related Links</span>
 			<ul class="wdn-related-links-v4">
                 <li><a href="http://www.huskeralum.org/">Alumni &amp; Friends</a></li>
                 <li><a href="http://emeriti.unl.edu/">Emeriti Association</a></li>

--- a/wdn/templates_4.1/includes/globalfooter.html
+++ b/wdn/templates_4.1/includes/globalfooter.html
@@ -1,7 +1,7 @@
 <div class="wdn-grid-set bp480-wdn-grid-set-thirds bp960-wdn-grid-set-fourths">
 	<div class="wdn-col">
 		<div class="wdn-footer-module wdn-footer-social">
-			<span role="heading">Connect with #UNL</span>
+			<span role="heading" aria-level="2">Connect with #UNL</span>
 			<ul class="wdn-footer-list">
 				<li><a href="https://www.facebook.com/UNLincoln" class="wdn-hang-icon"><span class="wdn-icon-facebook" aria-hidden="true"></span>UNLincoln <span class="wdn-text-hidden"> on Facebook</span></a></li>
 				<li><a href="https://twitter.com/UNLincoln" class="wdn-hang-icon"><span class="wdn-icon-twitter" aria-hidden="true"></span>@UNLincoln<span class="wdn-text-hidden"> on Twitter</span></a></li>
@@ -16,7 +16,7 @@
 	</div>
 	<div class="wdn-col">
 		<div class="wdn-footer-module wdn-footer-campus">
-			<span role="heading">Campus <span class="wdn-text-hidden">Links</span></span>
+			<span role="heading" aria-level="2">Campus <span class="wdn-text-hidden">Links</span></span>
 			<ul class="wdn-footer-list">
 				<li><a href="https://directory.unl.edu/" class="wdn-footer-list-item">Directory</a></li>
 				<li><a href="https://employment.unl.edu/" class="wdn-footer-list-item">Employment</a></li>
@@ -30,7 +30,7 @@
 	</div>
 	<div class="wdn-col">
 		<div class="wdn-footer-module wdn-footer-policies">
-			<span role="heading">Policies &amp; Reports</span>
+			<span role="heading" aria-level="2">Policies &amp; Reports</span>
 			<ul class="wdn-footer-list">
 				<li><a href="https://emergency.unl.edu/" class="wdn-footer-list-item">Emergency Planning and Preparedness</a></li>
 				<li><a href="https://www.unl.edu/equity/" class="wdn-footer-list-item">Institutional Equity and Compliance</a></li>


### PR DESCRIPTION
The way that AT implements this changed in aria 1.1 and now the way this is implemented in assistive technology is not consistent. We should update all of these to use `<h2>`, but adding an `aria-level="2"` has the same effect without having to change the styles.