### PR TITLE
Add initial 4.1 deprecated styles to 5.0

### DIFF
--- a/wdn/templates_5.0/scss/all.scss
+++ b/wdn/templates_5.0/scss/all.scss
@@ -65,3 +65,20 @@
 @import 'utilities/utilities.backgrounds';
 @import 'utilities/utilities.fonts';
 @import 'utilities/utilities.typography';
+
+
+// !Deprecated
+// TODO: create separate build task and CSS file for deprecated styles
+@import 'deprecated/deprecated.bands';
+@import 'deprecated/deprecated.columns';
+@import 'deprecated/deprecated.forms';
+@import 'deprecated/deprecated.grid';
+@import 'deprecated/deprecated.helpers';
+@import 'deprecated/deprecated.hero';
+@import 'deprecated/deprecated.images';
+@import 'deprecated/deprecated.pagination';
+@import 'deprecated/deprecated.promo-image';
+@import 'deprecated/deprecated.quote';
+@import 'deprecated/deprecated.tables';
+@import 'deprecated/deprecated.tabs';
+@import 'deprecated/deprecated.text';

--- a/wdn/templates_5.0/scss/deprecated/deprecated.bands.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.bands.scss
@@ -1,0 +1,61 @@
+//////////////////////////////
+// !THEME / DEPRECATED / BANDS
+//////////////////////////////
+
+
+.wdn-band {
+  left: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  position: relative;
+  right: 50%;
+  width: 100vw;
+}
+
+.wdn-inner-wrapper {
+  @include pb-9;
+  padding-left: 5.6%;
+  padding-right: 5.6%;
+  @include pt-9;
+}
+
+.wdn-inner-padding-sm {
+  @include pb-8;
+  @include pt-8;
+}
+
+.wdn-inner-padding-lg {
+  @include pb-10;
+  @include pt-10;
+}
+
+.wdn-inner-padding-no-top {
+  padding-top: 0;
+}
+
+.wdn-inner-padding-no-bottom {
+  padding-bottom: 0;
+}
+
+.wdn-inner-padding-none {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.wdn-stretch {
+  max-width: 100%;
+  width: 100%;
+}
+
+.wdn-center {
+  text-align: center;
+}
+
+@include mq(md) {
+
+  .wdn-text-band {
+    max-width: 37.5rem;
+    margin: 0 auto;
+  }
+
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.columns.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.columns.scss
@@ -1,0 +1,14 @@
+////////////////////////////////
+// !THEME / DEPRECATED / COLUMNS
+////////////////////////////////
+
+
+.wdn-two-flow-columns {
+  column-count: 2;
+  column-gap: 3.16vw;
+}
+
+.wdn-three-flow-columns {
+  column-count: 3;
+  column-gap: 3.16vw;
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.forms.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.forms.scss
@@ -1,0 +1,316 @@
+//////////////////////////////
+// !THEME / DEPRECATED / FORMS
+//////////////////////////////
+
+
+// Form
+form ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+form ul.wdn-std { // restore browser defaults, assumes LTR
+  list-style-type: disc;
+	margin: 1em 0;
+	padding-left: 40px;
+}
+
+form ul.wdn-std li { // restore browser defaults, assumes LTR
+  margin: 0;
+}
+
+// form label {
+//   @include font-sans;
+// }
+
+// // !Input: Control
+// .unl .dcf-input-control {
+//   @include mr-1;
+// }
+
+// !Input: File
+// .unl .dcf-input-file {
+//   @include mb-2;
+//   @include mt-2;
+// }
+
+form input[type="email"],
+form input[type="password"],
+form input[type="search"],
+form input[type="text"],
+form input[type="url"],
+form textarea {
+  border: 1px solid $color-border;
+  box-shadow: inset 0 1px 2px fade-out($color-border,1);
+  @include font-sans;
+  @include mb-4;
+  @include pb-2;
+  @include pl-3;
+  @include pr-3;
+  @include pt-2;
+  transition: border-color $hover-off, box-shadow $hover-off;
+  width: 100%;
+}
+
+form input[type="email"]:hover,
+form input[type="password"]:hover,
+form input[type="search"]:hover,
+form input[type="text"]:hover,
+form input[type="url"]:hover,
+form textarea:hover {
+  border-color: $color-border-hover;
+  box-shadow: inset 0 1px 2px fade-out($color-border,.5);
+  transition: border-color $hover-on, box-shadow $hover-on;
+}
+
+form input[type="email"]:focus,
+form input[type="password"]:focus,
+form input[type="search"]:focus,
+form input[type="text"]:focus,
+form input[type="url"]:focus,
+form textarea:focus {
+  border-color: $color-button;
+  outline: none;
+}
+
+form label + input[type="email"],
+form label + input[type="password"],
+form label + input[type="search"],
+form label + input[type="text"],
+form label + input[type="url"],
+form label + textarea {
+  @include mt-1;
+}
+
+
+@keyframes wdn-error {
+
+  from {
+    border: 1px solid $scarlet;
+    box-shadow: 0 0 6px fadeout($scarlet, 20%);
+  }
+
+  to {
+    border: 1px solid fadeout($scarlet, 80%);
+    box-shadow: 0 0 6px fadeout($scarlet, 90%);
+  }
+
+}
+
+form input.wdn-error,
+form textarea.wdn-error,
+form select.wdn-error {
+  animation: wdn-error 1.2s infinite alternate;
+  border: 1px solid $scarlet;
+}
+
+form span.required {
+  color: $scarlet;
+  font-size: #{ms(-2)}em;
+  font-style: italic;
+}
+
+form span.helper {
+  color: $color-lightest-text;
+  font-size: #{ms(-2)}em;
+}
+
+
+// Input Group
+.wdn-input-group {
+  display: flex;
+  width: 100%;
+}
+
+.wdn-input-group input[type='text'] {
+  flex-grow: 1;
+  margin-bottom: 0;
+  margin-top: 0;
+  width: 1%;
+}
+
+.wdn-input-group-btn {
+  align-items: center;
+  display: flex;
+  margin-bottom: 0;
+  margin-left: -1px;
+  margin-top: 0;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+
+// Button
+input[type='submit'],
+.wdn-button,
+.wdn-input-group-btn button,
+.wdn-input-group-btn input {
+  border-width: 2px;
+  border-style: solid;
+  cursor: pointer;
+  @include font-sans;
+  font-size: #{ms(-2)}em;
+  font-weight: bold;
+  @include ls-2;
+  padding-bottom: #{ms(-3)}em;
+  @include pl-5;
+  @include pr-5;
+  @include pt-3;
+  text-align: center;
+  text-transform: uppercase;
+  vertical-align: middle;
+//   -webkit-appearance: none;
+  white-space: nowrap;
+}
+
+input[type='submit'],
+.wdn-button {
+  display: inline-block;
+  text-decoration: none;
+}
+
+.wdn-input-group-btn button,
+.wdn-input-group-btn input {
+  align-self: stretch;
+  display: flex;
+}
+
+
+// Primary Button
+input[type='submit'],
+.wdn-button,
+.wdn-button:link,
+.wdn-button-brand,
+.wdn-button-brand:link,
+.wdn-input-group-btn button,
+.wdn-input-group-btn input {
+  background-color: $color-button;
+  border-color: $color-button;
+  color: $white;
+  transition: border $hover-off, background-color $hover-off;
+}
+
+input[type='submit']:focus,
+.wdn-button:focus,
+.wdn-button-brand:focus,
+.wdn-input-group-btn button:focus,
+.wdn-input-group-btn input:focus {
+  box-shadow: inset 0 0 0 3px currentColor;
+}
+
+.wdn-button:visited,
+.wdn-button-brand:visited {
+  background-color: $color-button-visited;
+  border-color: $color-button-visited;
+  color: $white;
+}
+
+input[type='submit']:hover,
+.wdn-button:hover,
+.wdn-button-brand:hover,
+.wdn-input-group-btn button:hover,
+.wdn-input-group-btn input:hover {
+  background-color: $color-button-hover;
+  border-color: $color-button-hover;
+  color: $white;
+  transition: border $hover-on, background-color $hover-on;
+}
+
+input[type='submit']:active,
+.wdn-button:active,
+.wdn-button-brand:active,
+.wdn-input-group-btn button:active,
+.wdn-input-group-btn input:active {
+  background-color: $color-button-active;
+  border-color: $color-button-active;
+  color: $white;
+}
+
+input[type='submit']:disabled,
+.wdn-button:disabled,
+.wdn-input-group-btn button:disabled,
+.wdn-input-group-btn input:disabled {
+  @include disabled;
+}
+
+
+// Secondary Button
+.wdn-button-complement,
+.wdn-button-complement:link,
+.wdn-button-energetic,
+.wdn-button-energetic:link,
+.wdn-button-triad,
+.wdn-button-triad:link {
+  background-color: transparent;
+  border-color: currentColor;
+  color: $color-button;
+  transition: background-color $hover-off, border-color $hover-off, color $hover-off;
+}
+
+.wdn-button-complement:focus,
+.wdn-button-energetic:focus,
+.wdn-button-triad:focus {
+  box-shadow: inset 0 0 0 3px $white, inset 0 0 0 4px currentColor;
+}
+
+.wdn-button-complement:visited,
+.wdn-button-energetic:visited,
+.wdn-button-triad:visited {
+  border-color: currentColor;
+  color: $color-button-visited;
+}
+
+.wdn-button-complement:hover,
+.wdn-button-energetic:hover,
+.wdn-button-triad:hover {
+  background-color: fade-out($color-button-hover,.9);
+  border-color: currentColor;
+  color: $color-button-hover;
+  transition: background-color $hover-on, border-color $hover-on, color $hover-on;
+}
+
+.wdn-button-complement:active,
+.wdn-button-energetic:active,
+.wdn-button-triad:active {
+  border-color: currentColor;
+  color: $color-button-active;
+}
+
+
+// Outline Button
+.wdn-button-outline,
+.wdn-button-outline:link {
+  background-color: rgba(0,0,0,.1);
+  border-color: currentColor;
+  color: $white;
+  transition: background-color $hover-off;
+}
+
+.wdn-button-outline:hover {
+  background-color: rgba(0,0,0,.2);
+  transition: background-color $hover-on;
+}
+
+
+// Webform opt-out
+.wdn-webform-opt-out ol,
+.wdn-webform-opt-out ul {
+  padding-left: 1em;
+}
+
+.wdn-webform-opt-out ol {
+  list-style-type: decimal;
+}
+
+.wdn-webform-opt-out ul {
+  list-style-type: disc;
+}
+
+.wdn-webform-opt-out li {
+  margin: 0;
+}
+
+.wdn-webform-opt-out li li {
+  margin: 0;
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.grid.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.grid.scss
@@ -1,0 +1,1180 @@
+/////////////////////////////
+// !THEME / DEPRECATED / GRID
+/////////////////////////////
+
+
+[class*=wdn-grid-set] {
+//   box-sizing: border-box;
+  clear: left;
+  margin: 0 -1.58vw;
+}
+
+[class*=wdn-grid-set]:after {
+  clear: both;
+  content: '';
+  display: table;
+}
+
+[class*=wdn-grid-set] > [class*=wdn-grid-set] {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+[class*=wdn-col] {
+//   box-sizing: border-box;
+  float: left;
+  padding: 0 1.58vw;
+  width: 100%;
+}
+
+[class*=wdn-col].col-padding {
+  background-clip: content-box;
+  padding: 1.58vw 0 1.58vw 3.16vw;
+}
+
+.wdn-grid-clear[class*=wdn-grid-set-halves] .wdn-col:nth-child(2n+1),
+.wdn-grid-clear[class*=wdn-grid-set-thirds] .wdn-col:nth-child(3n+1),
+.wdn-grid-clear[class*=wdn-grid-set-fourths] .wdn-col:nth-child(4n+1),
+.wdn-grid-clear[class*=wdn-grid-set-fifths] .wdn-col:nth-child(5n+1),
+.wdn-grid-clear[class*=wdn-grid-set-sixths] .wdn-col:nth-child(6n+1),
+.wdn-grid-clear[class*=wdn-grid-set-sevenths] .wdn-col:nth-child(7n+1),
+.wdn-grid-clear[class*=wdn-grid-set-eighths] .wdn-col:nth-child(8n+1),
+.wdn-grid-clear[class*=wdn-grid-set-ninths] .wdn-col:nth-child(9n+1),
+.wdn-grid-clear[class*=wdn-grid-set-tenths] .wdn-col:nth-child(10n+1) {
+  clear: left;
+}
+
+[class*=wdn-col] .visual-island {
+  padding: 0 1.58vw;
+}
+
+#dcf-main ol[class*=wdn-grid-set],
+#dcf-main ul[class*=wdn-grid-set] {
+  list-style: none;
+  padding: 0;
+}
+
+li.wdn-col {
+  margin-bottom: 0;
+  margin-left: 0;
+}
+
+.wdn-col-full,
+.wdn-grid-set-full .wdn-col {
+  width: 100%;
+}
+
+.wdn-col-five-tenths,
+.wdn-col-four-eighths,
+.wdn-col-one-half,
+.wdn-col-three-sixths,
+.wdn-col-two-fourths,
+.wdn-grid-set-halves .wdn-col {
+  width: 50%;
+}
+
+.wdn-col-one-third,
+.wdn-col-three-ninths,
+.wdn-col-two-sixths,
+.wdn-grid-set-thirds .wdn-col {
+  width: 33.33333333%;
+}
+
+.wdn-col-four-sixths,
+.wdn-col-six-ninths,
+.wdn-col-two-thirds {
+  width: 66.66666667%;
+}
+
+.wdn-col-one-fourth,
+.wdn-col-two-eighths,
+.wdn-grid-set-fourths .wdn-col {
+  width: 25%;
+}
+
+.wdn-col-six-eighths,
+.wdn-col-three-fourths {
+  width: 75%;
+}
+
+.wdn-col-one-fifth,
+.wdn-col-two-tenths,
+.wdn-grid-set-fifths .wdn-col {
+  width: 20%;
+}
+
+.wdn-col-four-tenths,
+.wdn-col-two-fifths {
+  width: 40%;
+}
+
+.wdn-col-six-tenths,
+.wdn-col-three-fifths {
+  width: 60%;
+}
+
+.wdn-col-eight-tenths,
+.wdn-col-four-fifths {
+  width: 80%;
+}
+
+.wdn-col-one-sixth,
+.wdn-grid-set-sixths .wdn-col {
+  width: 16.66666667%;
+}
+
+.wdn-col-five-sixths {
+  width: 83.33333333%;
+}
+
+.wdn-col-one-seventh,
+.wdn-grid-set-sevenths .wdn-col {
+  width: 14.28571429%;
+}
+
+.wdn-col-two-sevenths {
+  width: 28.57142857%;
+}
+
+.wdn-col-three-sevenths {
+  width: 42.85714286%;
+}
+
+.wdn-col-four-sevenths {
+  width: 57.14285714%;
+}
+
+.wdn-col-five-sevenths {
+  width: 71.42857143%;
+}
+
+.wdn-col-six-sevenths {
+  width: 85.71428571%;
+}
+
+.wdn-col-one-eighth,
+.wdn-grid-set-eighths .wdn-col {
+  width: 12.5%;
+}
+
+.wdn-col-three-eighths {
+  width: 37.5%;
+}
+
+.wdn-col-five-eighths {
+  width: 62.5%;
+}
+
+.wdn-col-seven-eighths {
+  width: 87.5%;
+}
+
+.wdn-col-one-ninth,
+.wdn-grid-set-ninths .wdn-col {
+  width: 11.11111111%;
+}
+
+.wdn-col-two-ninths {
+  width: 22.22222222%;
+}
+
+.wdn-col-four-ninths {
+  width: 44.44444444%;
+}
+
+.wdn-col-five-ninths {
+	width: 55.55555556%;
+}
+
+.wdn-col-seven-ninths {
+  width: 77.77777778%;
+}
+
+.wdn-col-eight-ninths {
+  width: 88.88888889%;
+}
+
+.wdn-col-one-tenth,
+.wdn-grid-set-tenths .wdn-col {
+  width: 10%;
+}
+
+.wdn-col-three-tenths {
+  width: 30%;
+}
+
+.wdn-col-seven-tenths {
+  width: 70%;
+}
+
+.wdn-col-nine-tenths {
+  width: 90%;
+}
+
+
+// Map 'bp480' (~480 px), 'bp640' (~640 px) and 'bp768' (~768 px) to 'sm' breakpoint (~671.3 px)
+@include mq(sm) {
+
+  .bp480-wdn-col-full,
+  .bp480-wdn-grid-set-full .wdn-col,
+  .bp640-wdn-col-full,
+  .bp640-wdn-grid-set-full .wdn-col,
+  .bp768-wdn-col-full,
+  .bp768-wdn-grid-set-full .wdn-col,
+  .bp1-wdn-col-full,
+  .bp1-wdn-grid-set-full .wdn-col,
+  .bp2-wdn-col-full,
+  .bp2-wdn-grid-set-full .wdn-col {
+    width: 100%;
+  }
+
+  .bp480-wdn-col-five-tenths,
+  .bp480-wdn-col-four-eighths,
+  .bp480-wdn-col-one-half,
+  .bp480-wdn-col-three-sixths,
+  .bp480-wdn-col-two-fourths,
+  .bp480-wdn-grid-set-halves .wdn-col,
+  .bp640-wdn-col-five-tenths,
+  .bp640-wdn-col-four-eighths,
+  .bp640-wdn-col-one-half,
+  .bp640-wdn-col-three-sixths,
+  .bp640-wdn-col-two-fourths,
+  .bp640-wdn-grid-set-halves .wdn-col,
+  .bp768-wdn-col-five-tenths,
+  .bp768-wdn-col-four-eighths,
+  .bp768-wdn-col-one-half,
+  .bp768-wdn-col-three-sixths,
+  .bp768-wdn-col-two-fourths,
+  .bp768-wdn-grid-set-halves .wdn-col,
+  .bp1-wdn-col-five-tenths,
+  .bp1-wdn-col-four-eighths,
+  .bp1-wdn-col-one-half,
+  .bp1-wdn-col-three-sixths,
+  .bp1-wdn-col-two-fourths,
+  .bp1-wdn-grid-set-halves .wdn-col,
+  .bp2-wdn-col-five-tenths,
+  .bp2-wdn-col-four-eighths,
+  .bp2-wdn-col-one-half,
+  .bp2-wdn-col-three-sixths,
+  .bp2-wdn-col-two-fourths,
+  .bp2-wdn-grid-set-halves .wdn-col {
+    width: 50%;
+  }
+
+  .bp480-wdn-col-one-third,
+  .bp480-wdn-col-three-ninths,
+  .bp480-wdn-col-two-sixths,
+  .bp480-wdn-grid-set-thirds .wdn-col,
+  .bp640-wdn-col-one-third,
+  .bp640-wdn-col-three-ninths,
+  .bp640-wdn-col-two-sixths,
+  .bp640-wdn-grid-set-thirds .wdn-col,
+  .bp768-wdn-col-one-third,
+  .bp768-wdn-col-three-ninths,
+  .bp768-wdn-col-two-sixths,
+  .bp768-wdn-grid-set-thirds .wdn-col,
+  .bp1-wdn-col-one-third,
+  .bp1-wdn-col-three-ninths,
+  .bp1-wdn-col-two-sixths,
+  .bp1-wdn-grid-set-thirds .wdn-col,
+  .bp2-wdn-col-one-third,
+  .bp2-wdn-col-three-ninths,
+  .bp2-wdn-col-two-sixths,
+  .bp2-wdn-grid-set-thirds .wdn-col {
+    width: 33.33333333%;
+  }
+
+  .bp480-wdn-col-four-sixths,
+  .bp480-wdn-col-six-ninths,
+  .bp480-wdn-col-two-thirds,
+  .bp640-wdn-col-four-sixths,
+  .bp640-wdn-col-six-ninths,
+  .bp640-wdn-col-two-thirds,
+  .bp768-wdn-col-four-sixths,
+  .bp768-wdn-col-six-ninths,
+  .bp768-wdn-col-two-thirds,
+  .bp1-wdn-col-four-sixths,
+  .bp1-wdn-col-six-ninths,
+  .bp1-wdn-col-two-thirds,
+  .bp2-wdn-col-four-sixths,
+  .bp2-wdn-col-six-ninths,
+  .bp2-wdn-col-two-thirds {
+    width: 66.66666667%;
+  }
+
+  .bp480-wdn-col-one-fourth,
+  .bp480-wdn-col-two-eighths,
+  .bp480-wdn-grid-set-fourths .wdn-col,
+  .bp640-wdn-col-one-fourth,
+  .bp640-wdn-col-two-eighths,
+  .bp640-wdn-grid-set-fourths .wdn-col,
+  .bp768-wdn-col-one-fourth,
+  .bp768-wdn-col-two-eighths,
+  .bp768-wdn-grid-set-fourths .wdn-col,
+  .bp1-wdn-col-one-fourth,
+  .bp1-wdn-col-two-eighths,
+  .bp1-wdn-grid-set-fourths .wdn-col,
+  .bp2-wdn-col-one-fourth,
+  .bp2-wdn-col-two-eighths,
+  .bp2-wdn-grid-set-fourths .wdn-col {
+    width: 25%;
+  }
+
+  .bp480-wdn-col-six-eighths,
+  .bp480-wdn-col-three-fourths,
+  .bp640-wdn-col-six-eighths,
+  .bp640-wdn-col-three-fourths,
+  .bp768-wdn-col-six-eighths,
+  .bp768-wdn-col-three-fourths,
+  .bp1-wdn-col-six-eighths,
+  .bp1-wdn-col-three-fourths,
+  .bp2-wdn-col-six-eighths,
+  .bp2-wdn-col-three-fourths {
+    width: 75%;
+  }
+
+  .bp480-wdn-col-one-fifth,
+  .bp480-wdn-col-two-tenths,
+  .bp480-wdn-grid-set-fifths .wdn-col,
+  .bp640-wdn-col-one-fifth,
+  .bp640-wdn-col-two-tenths,
+  .bp640-wdn-grid-set-fifths .wdn-col,
+  .bp768-wdn-col-one-fifth,
+  .bp768-wdn-col-two-tenths,
+  .bp768-wdn-grid-set-fifths .wdn-col,
+  .bp1-wdn-col-one-fifth,
+  .bp1-wdn-col-two-tenths,
+  .bp1-wdn-grid-set-fifths .wdn-col,
+  .bp2-wdn-col-one-fifth,
+  .bp2-wdn-col-two-tenths,
+  .bp2-wdn-grid-set-fifths .wdn-col {
+    width: 20%;
+  }
+
+  .bp480-wdn-col-four-tenths,
+  .bp480-wdn-col-two-fifths,
+  .bp640-wdn-col-four-tenths,
+  .bp640-wdn-col-two-fifths,
+  .bp768-wdn-col-four-tenths,
+  .bp768-wdn-col-two-fifths,
+  .bp1-wdn-col-four-tenths,
+  .bp1-wdn-col-two-fifths,
+  .bp2-wdn-col-four-tenths,
+  .bp2-wdn-col-two-fifths {
+    width: 40%;
+  }
+
+  .bp480-wdn-col-six-tenths,
+  .bp480-wdn-col-three-fifths,
+  .bp640-wdn-col-six-tenths,
+  .bp640-wdn-col-three-fifths,
+  .bp768-wdn-col-six-tenths,
+  .bp768-wdn-col-three-fifths,
+  .bp1-wdn-col-six-tenths,
+  .bp1-wdn-col-three-fifths,
+  .bp2-wdn-col-six-tenths,
+  .bp2-wdn-col-three-fifths {
+    width: 60%;
+  }
+
+  .bp480-wdn-col-eight-tenths,
+  .bp480-wdn-col-four-fifths,
+  .bp640-wdn-col-eight-tenths,
+  .bp640-wdn-col-four-fifths,
+  .bp768-wdn-col-eight-tenths,
+  .bp768-wdn-col-four-fifths,
+  .bp1-wdn-col-eight-tenths,
+  .bp1-wdn-col-four-fifths,
+  .bp2-wdn-col-eight-tenths,
+  .bp2-wdn-col-four-fifths {
+    width: 80%;
+  }
+
+  .bp480-wdn-col-one-sixth,
+  .bp480-wdn-grid-set-sixths .wdn-col,
+  .bp640-wdn-col-one-sixth,
+  .bp640-wdn-grid-set-sixths .wdn-col,
+  .bp768-wdn-col-one-sixth,
+  .bp768-wdn-grid-set-sixths .wdn-col,
+  .bp1-wdn-col-one-sixth,
+  .bp1-wdn-grid-set-sixths .wdn-col,
+  .bp2-wdn-col-one-sixth,
+  .bp2-wdn-grid-set-sixths .wdn-col {
+    width: 16.66666667%;
+  }
+
+  .bp480-wdn-col-five-sixths,
+  .bp640-wdn-col-five-sixths,
+  .bp768-wdn-col-five-sixths,
+  .bp1-wdn-col-five-sixths,
+  .bp2-wdn-col-five-sixths {
+    width: 83.33333333%;
+  }
+
+  .bp480-wdn-col-one-seventh,
+  .bp480-wdn-grid-set-sevenths .wdn-col,
+  .bp640-wdn-col-one-seventh,
+  .bp640-wdn-grid-set-sevenths .wdn-col,
+  .bp768-wdn-col-one-seventh,
+  .bp768-wdn-grid-set-sevenths .wdn-col,
+  .bp1-wdn-col-one-seventh,
+  .bp1-wdn-grid-set-sevenths .wdn-col,
+  .bp2-wdn-col-one-seventh,
+  .bp2-wdn-grid-set-sevenths .wdn-col {
+    width: 14.28571429%;
+  }
+
+  .bp480-wdn-col-two-sevenths,
+  .bp640-wdn-col-two-sevenths,
+  .bp768-wdn-col-two-sevenths,
+  .bp1-wdn-col-two-sevenths,
+  .bp2-wdn-col-two-sevenths {
+    width: 28.57142857%;
+  }
+
+  .bp480-wdn-col-three-sevenths,
+  .bp640-wdn-col-three-sevenths,
+  .bp768-wdn-col-three-sevenths,
+  .bp1-wdn-col-three-sevenths,
+  .bp2-wdn-col-three-sevenths {
+    width: 42.85714286%;
+  }
+
+  .bp480-wdn-col-four-sevenths,
+  .bp640-wdn-col-four-sevenths,
+  .bp768-wdn-col-four-sevenths,
+  .bp1-wdn-col-four-sevenths,
+  .bp2-wdn-col-four-sevenths {
+    width: 57.14285714%;
+  }
+
+  .bp480-wdn-col-five-sevenths,
+  .bp640-wdn-col-five-sevenths,
+  .bp768-wdn-col-five-sevenths,
+  .bp1-wdn-col-five-sevenths,
+  .bp2-wdn-col-five-sevenths {
+    width: 71.42857143%;
+  }
+
+  .bp480-wdn-col-six-sevenths,
+  .bp640-wdn-col-six-sevenths,
+  .bp768-wdn-col-six-sevenths,
+  .bp1-wdn-col-six-sevenths,
+  .bp2-wdn-col-six-sevenths {
+    width: 85.71428571%;
+  }
+
+  .bp480-wdn-col-one-eighth,
+  .bp480-wdn-grid-set-eighths .wdn-col,
+  .bp640-wdn-col-one-eighth,
+  .bp640-wdn-grid-set-eighths .wdn-col,
+  .bp768-wdn-col-one-eighth,
+  .bp768-wdn-grid-set-eighths .wdn-col,
+  .bp1-wdn-col-one-eighth,
+  .bp1-wdn-grid-set-eighths .wdn-col,
+  .bp2-wdn-col-one-eighth,
+  .bp2-wdn-grid-set-eighths .wdn-col {
+    width: 12.5%;
+  }
+
+  .bp480-wdn-col-three-eighths,
+  .bp640-wdn-col-three-eighths,
+  .bp768-wdn-col-three-eighths,
+  .bp1-wdn-col-three-eighths,
+  .bp2-wdn-col-three-eighths {
+    width: 37.5%;
+  }
+
+  .bp480-wdn-col-five-eighths,
+  .bp640-wdn-col-five-eighths,
+  .bp768-wdn-col-five-eighths,
+  .bp1-wdn-col-five-eighths,
+  .bp2-wdn-col-five-eighths {
+    width: 62.5%;
+  }
+
+  .bp480-wdn-col-seven-eighths,
+  .bp640-wdn-col-seven-eighths,
+  .bp768-wdn-col-seven-eighths,
+  .bp1-wdn-col-seven-eighths,
+  .bp2-wdn-col-seven-eighths {
+    width: 87.5%;
+  }
+
+  .bp480-wdn-col-one-ninth,
+  .bp480-wdn-grid-set-ninths .wdn-col,
+  .bp640-wdn-col-one-ninth,
+  .bp640-wdn-grid-set-ninths .wdn-col,
+  .bp768-wdn-col-one-ninth,
+  .bp768-wdn-grid-set-ninths .wdn-col,
+  .bp1-wdn-col-one-ninth,
+  .bp1-wdn-grid-set-ninths .wdn-col,
+  .bp2-wdn-col-one-ninth,
+  .bp2-wdn-grid-set-ninths .wdn-col {
+    width: 11.11111111%;
+  }
+
+  .bp480-wdn-col-two-ninths,
+  .bp640-wdn-col-two-ninths,
+  .bp768-wdn-col-two-ninths,
+  .bp1-wdn-col-two-ninths,
+  .bp2-wdn-col-two-ninths {
+    width: 22.22222222%;
+  }
+
+  .bp480-wdn-col-four-ninths,
+  .bp640-wdn-col-four-ninths,
+  .bp768-wdn-col-four-ninths,
+  .bp1-wdn-col-four-ninths,
+  .bp2-wdn-col-four-ninths {
+    width: 44.44444444%;
+  }
+
+  .bp480-wdn-col-five-ninths,
+  .bp640-wdn-col-five-ninths,
+  .bp768-wdn-col-five-ninths,
+  .bp1-wdn-col-five-ninths,
+  .bp2-wdn-col-five-ninths {
+    width: 55.55555556%;
+  }
+
+  .bp480-wdn-col-seven-ninths,
+  .bp640-wdn-col-seven-ninths,
+  .bp768-wdn-col-seven-ninths,
+  .bp1-wdn-col-seven-ninths,
+  .bp2-wdn-col-seven-ninths {
+    width: 77.77777778%;
+  }
+
+  .bp480-wdn-col-eight-ninths,
+  .bp640-wdn-col-eight-ninths,
+  .bp768-wdn-col-eight-ninths,
+  .bp1-wdn-col-eight-ninths,
+  .bp2-wdn-col-eight-ninths {
+    width: 88.88888889%;
+  }
+
+  .bp480-wdn-col-one-tenth,
+  .bp480-wdn-grid-set-tenths .wdn-col,
+  .bp640-wdn-col-one-tenth,
+  .bp640-wdn-grid-set-tenths .wdn-col,
+  .bp768-wdn-col-one-tenth,
+  .bp768-wdn-grid-set-tenths .wdn-col,
+  .bp1-wdn-col-one-tenth,
+  .bp1-wdn-grid-set-tenths .wdn-col,
+  .bp2-wdn-col-one-tenth,
+  .bp2-wdn-grid-set-tenths .wdn-col {
+    width: 10%;
+  }
+
+  .bp480-wdn-col-three-tenths,
+  .bp640-wdn-col-three-tenths,
+  .bp768-wdn-col-three-tenths,
+  .bp1-wdn-col-three-tenths,
+  .bp2-wdn-col-three-tenths {
+    width: 30%;
+  }
+
+  .bp480-wdn-col-seven-tenths,
+  .bp640-wdn-col-seven-tenths,
+  .bp768-wdn-col-seven-tenths,
+  .bp1-wdn-col-seven-tenths,
+  .bp2-wdn-col-seven-tenths {
+    width: 70%;
+  }
+
+  .bp480-wdn-col-nine-tenths,
+  .bp640-wdn-col-nine-tenths,
+  .bp768-wdn-col-nine-tenths,
+  .bp1-wdn-col-nine-tenths,
+  .bp2-wdn-col-nine-tenths {
+    width: 90%;
+  }
+
+}
+
+
+// Map 'bp960' (~960 px) to 'md' breakpoint (~894.8 px)
+@include mq(md) {
+
+  .bp960-wdn-col-full,
+  .bp960-wdn-grid-set-full .wdn-col,
+  .bp3-wdn-col-full,
+  .bp3-wdn-grid-set-full .wdn-col {
+    width: 100%;
+  }
+
+  .bp960-wdn-col-five-tenths,
+  .bp960-wdn-col-four-eighths,
+  .bp960-wdn-col-one-half,
+  .bp960-wdn-col-three-sixths,
+  .bp960-wdn-col-two-fourths,
+  .bp960-wdn-grid-set-halves .wdn-col,
+  .bp3-wdn-col-five-tenths,
+  .bp3-wdn-col-four-eighths,
+  .bp3-wdn-col-one-half,
+  .bp3-wdn-col-three-sixths,
+  .bp3-wdn-col-two-fourths,
+  .bp3-wdn-grid-set-halves .wdn-col {
+    width: 50%;
+  }
+
+  .bp960-wdn-col-one-third,
+  .bp960-wdn-col-three-ninths,
+  .bp960-wdn-col-two-sixths,
+  .bp960-wdn-grid-set-thirds .wdn-col,
+  .bp3-wdn-col-one-third,
+  .bp3-wdn-col-three-ninths,
+  .bp3-wdn-col-two-sixths,
+  .bp3-wdn-grid-set-thirds .wdn-col {
+    width: 33.33333333%;
+  }
+
+  .bp960-wdn-col-four-sixths,
+  .bp960-wdn-col-six-ninths,
+  .bp960-wdn-col-two-thirds,
+  .bp3-wdn-col-four-sixths,
+  .bp3-wdn-col-six-ninths,
+  .bp3-wdn-col-two-thirds {
+    width: 66.66666667%;
+  }
+
+  .bp960-wdn-col-one-fourth,
+  .bp960-wdn-col-two-eighths,
+  .bp960-wdn-grid-set-fourths .wdn-col,
+  .bp3-wdn-col-one-fourth,
+  .bp3-wdn-col-two-eighths,
+  .bp3-wdn-grid-set-fourths .wdn-col {
+    width: 25%;
+  }
+
+  .bp960-wdn-col-six-eighths,
+  .bp960-wdn-col-three-fourths,
+  .bp3-wdn-col-six-eighths,
+  .bp3-wdn-col-three-fourths {
+    width: 75%;
+  }
+
+  .bp960-wdn-col-one-fifth,
+  .bp960-wdn-col-two-tenths,
+  .bp960-wdn-grid-set-fifths .wdn-col,
+  .bp3-wdn-col-one-fifth,
+  .bp3-wdn-col-two-tenths,
+  .bp3-wdn-grid-set-fifths .wdn-col {
+    width: 20%;
+  }
+
+  .bp960-wdn-col-four-tenths,
+  .bp960-wdn-col-two-fifths,
+  .bp3-wdn-col-four-tenths,
+  .bp3-wdn-col-two-fifths {
+    width: 40%;
+  }
+
+  .bp960-wdn-col-six-tenths,
+  .bp960-wdn-col-three-fifths,
+  .bp3-wdn-col-six-tenths,
+  .bp3-wdn-col-three-fifths {
+    width: 60%;
+  }
+
+  .bp960-wdn-col-eight-tenths,
+  .bp960-wdn-col-four-fifths,
+  .bp3-wdn-col-eight-tenths,
+  .bp3-wdn-col-four-fifths {
+    width: 80%;
+  }
+
+  .bp960-wdn-col-one-sixth,
+  .bp960-wdn-grid-set-sixths .wdn-col,
+  .bp3-wdn-col-one-sixth,
+  .bp3-wdn-grid-set-sixths .wdn-col {
+    width: 16.66666667%;
+  }
+
+  .bp960-wdn-col-five-sixths,
+  .bp3-wdn-col-five-sixths {
+    width: 83.33333333%;
+  }
+
+  .bp960-wdn-col-one-seventh,
+  .bp960-wdn-grid-set-sevenths .wdn-col,
+  .bp3-wdn-col-one-seventh,
+  .bp3-wdn-grid-set-sevenths .wdn-col {
+    width: 14.28571429%;
+  }
+
+  .bp960-wdn-col-two-sevenths,
+  .bp3-wdn-col-two-sevenths {
+    width: 28.57142857%;
+  }
+
+  .bp960-wdn-col-three-sevenths,
+  .bp3-wdn-col-three-sevenths {
+    width: 42.85714286%;
+  }
+
+  .bp960-wdn-col-four-sevenths,
+  .bp3-wdn-col-four-sevenths {
+    width: 57.14285714%;
+  }
+
+  .bp960-wdn-col-five-sevenths,
+  .bp3-wdn-col-five-sevenths {
+    width: 71.42857143%;
+  }
+
+  .bp960-wdn-col-six-sevenths,
+  .bp3-wdn-col-six-sevenths {
+    width: 85.71428571%;
+  }
+
+  .bp960-wdn-col-one-eighth,
+  .bp960-wdn-grid-set-eighths .wdn-col,
+  .bp3-wdn-col-one-eighth,
+  .bp3-wdn-grid-set-eighths .wdn-col {
+    width: 12.5%;
+  }
+
+  .bp960-wdn-col-three-eighths,
+  .bp3-wdn-col-three-eighths {
+    width: 37.5%;
+  }
+
+  .bp960-wdn-col-five-eighths,
+  .bp3-wdn-col-five-eighths {
+    width: 62.5%;
+  }
+
+  .bp960-wdn-col-seven-eighths,
+  .bp3-wdn-col-seven-eighths {
+    width: 87.5%;
+  }
+
+  .bp960-wdn-col-one-ninth,
+  .bp960-wdn-grid-set-ninths .wdn-col,
+  .bp3-wdn-col-one-ninth,
+  .bp3-wdn-grid-set-ninths .wdn-col {
+    width: 11.11111111%;
+  }
+
+  .bp960-wdn-col-two-ninths,
+  .bp3-wdn-col-two-ninths {
+    width: 22.22222222%;
+  }
+
+  .bp960-wdn-col-four-ninths,
+  .bp3-wdn-col-four-ninths {
+    width: 44.44444444%;
+  }
+
+  .bp960-wdn-col-five-ninths,
+  .bp3-wdn-col-five-ninths {
+    width: 55.55555556%;
+  }
+
+  .bp960-wdn-col-seven-ninths,
+  .bp3-wdn-col-seven-ninths {
+    width: 77.77777778%;
+  }
+
+  .bp960-wdn-col-eight-ninths,
+  .bp3-wdn-col-eight-ninths {
+    width: 88.88888889%;
+  }
+
+  .bp960-wdn-col-one-tenth,
+  .bp960-wdn-grid-set-tenths .wdn-col,
+  .bp3-wdn-col-one-tenth,
+  .bp3-wdn-grid-set-tenths .wdn-col {
+    width: 10%;
+  }
+
+  .bp960-wdn-col-three-tenths,
+  .bp3-wdn-col-three-tenths {
+    width: 30%;
+  }
+
+  .bp960-wdn-col-seven-tenths,
+  .bp3-wdn-col-seven-tenths {
+    width: 70%;
+  }
+
+  .bp960-wdn-col-nine-tenths,
+  .bp3-wdn-col-nine-tenths {
+    width: 90%;
+  }
+
+}
+
+
+// Map 'bp1280' (~1280 px) to 'lg' breakpoint (~1192.8 px)
+@include mq(lg) {
+
+  .bp1280-wdn-col-full,
+  .bp1280-wdn-grid-set-full .wdn-col,
+  .bp4-wdn-col-full,
+  .bp4-wdn-grid-set-full .wdn-col {
+    width: 100%;
+  }
+
+  .bp1280-wdn-col-five-tenths,
+  .bp1280-wdn-col-four-eighths,
+  .bp1280-wdn-col-one-half,
+  .bp1280-wdn-col-three-sixths,
+  .bp1280-wdn-col-two-fourths,
+  .bp1280-wdn-grid-set-halves .wdn-col,
+  .bp4-wdn-col-five-tenths,
+  .bp4-wdn-col-four-eighths,
+  .bp4-wdn-col-one-half,
+  .bp4-wdn-col-three-sixths,
+  .bp4-wdn-col-two-fourths,
+  .bp4-wdn-grid-set-halves .wdn-col {
+    width: 50%;
+  }
+
+  .bp1280-wdn-col-one-third,
+  .bp1280-wdn-col-three-ninths,
+  .bp1280-wdn-col-two-sixths,
+  .bp1280-wdn-grid-set-thirds .wdn-col,
+  .bp4-wdn-col-one-third,
+  .bp4-wdn-col-three-ninths,
+  .bp4-wdn-col-two-sixths,
+  .bp4-wdn-grid-set-thirds .wdn-col {
+    width: 33.33333333%;
+  }
+
+  .bp1280-wdn-col-four-sixths,
+  .bp1280-wdn-col-six-ninths,
+  .bp1280-wdn-col-two-thirds,
+  .bp4-wdn-col-four-sixths,
+  .bp4-wdn-col-six-ninths,
+  .bp4-wdn-col-two-thirds {
+	  width: 66.66666667%;
+  }
+
+  .bp1280-wdn-col-one-fourth,
+  .bp1280-wdn-col-two-eighths,
+  .bp1280-wdn-grid-set-fourths .wdn-col,
+  .bp4-wdn-col-one-fourth,
+  .bp4-wdn-col-two-eighths,
+  .bp4-wdn-grid-set-fourths .wdn-col {
+    width: 25%;
+  }
+
+  .bp1280-wdn-col-six-eighths,
+  .bp1280-wdn-col-three-fourths,
+  .bp4-wdn-col-six-eighths,
+  .bp4-wdn-col-three-fourths {
+    width: 75%;
+  }
+
+  .bp1280-wdn-col-one-fifth,
+  .bp1280-wdn-col-two-tenths,
+  .bp1280-wdn-grid-set-fifths .wdn-col,
+  .bp4-wdn-col-one-fifth,
+  .bp4-wdn-col-two-tenths,
+  .bp4-wdn-grid-set-fifths .wdn-col {
+    width: 20%;
+  }
+
+  .bp1280-wdn-col-four-tenths,
+  .bp1280-wdn-col-two-fifths,
+  .bp4-wdn-col-four-tenths,
+  .bp4-wdn-col-two-fifths {
+    width: 40%;
+  }
+
+  .bp1280-wdn-col-six-tenths,
+  .bp1280-wdn-col-three-fifths,
+  .bp4-wdn-col-six-tenths,
+  .bp4-wdn-col-three-fifths {
+    width: 60%;
+  }
+
+  .bp1280-wdn-col-eight-tenths,
+  .bp1280-wdn-col-four-fifths,
+  .bp4-wdn-col-eight-tenths,
+  .bp4-wdn-col-four-fifths {
+    width: 80%;
+  }
+
+  .bp1280-wdn-col-one-sixth,
+  .bp1280-wdn-grid-set-sixths .wdn-col,
+  .bp4-wdn-col-one-sixth,
+  .bp4-wdn-grid-set-sixths .wdn-col {
+    width: 16.66666667%;
+  }
+
+  .bp1280-wdn-col-five-sixths,
+  .bp4-wdn-col-five-sixths {
+    width: 83.33333333%;
+  }
+
+  .bp1280-wdn-col-one-seventh,
+  .bp1280-wdn-grid-set-sevenths .wdn-col,
+  .bp4-wdn-col-one-seventh,
+  .bp4-wdn-grid-set-sevenths .wdn-col {
+    width: 14.28571429%;
+  }
+
+  .bp1280-wdn-col-two-sevenths,
+  .bp4-wdn-col-two-sevenths {
+    width: 28.57142857%;
+  }
+
+  .bp1280-wdn-col-three-sevenths,
+  .bp4-wdn-col-three-sevenths {
+    width: 42.85714286%;
+  }
+
+  .bp1280-wdn-col-four-sevenths,
+  .bp4-wdn-col-four-sevenths {
+    width: 57.14285714%;
+  }
+
+  .bp1280-wdn-col-five-sevenths,
+  .bp4-wdn-col-five-sevenths {
+    width: 71.42857143%;
+  }
+
+  .bp1280-wdn-col-six-sevenths,
+  .bp4-wdn-col-six-sevenths {
+    width: 85.71428571%;
+  }
+
+  .bp1280-wdn-col-one-eighth,
+  .bp1280-wdn-grid-set-eighths .wdn-col,
+  .bp4-wdn-col-one-eighth,
+  .bp4-wdn-grid-set-eighths .wdn-col {
+    width: 12.5%;
+  }
+
+  .bp1280-wdn-col-three-eighths,
+  .bp4-wdn-col-three-eighths {
+    width: 37.5%;
+  }
+
+  .bp1280-wdn-col-five-eighths,
+  .bp4-wdn-col-five-eighths {
+    width: 62.5%;
+  }
+
+  .bp1280-wdn-col-seven-eighths,
+  .bp4-wdn-col-seven-eighths {
+    width: 87.5%;
+  }
+
+  .bp1280-wdn-col-one-ninth,
+  .bp1280-wdn-grid-set-ninths .wdn-col,
+  .bp4-wdn-col-one-ninth,
+  .bp4-wdn-grid-set-ninths .wdn-col {
+    width: 11.11111111%;
+  }
+
+  .bp1280-wdn-col-two-ninths,
+  .bp4-wdn-col-two-ninths {
+    width: 22.22222222%;
+  }
+
+  .bp1280-wdn-col-four-ninths,
+  .bp4-wdn-col-four-ninths {
+    width: 44.44444444%;
+  }
+
+  .bp1280-wdn-col-five-ninths,
+  .bp4-wdn-col-five-ninths {
+    width: 55.55555556%;
+  }
+
+  .bp1280-wdn-col-seven-ninths,
+  .bp4-wdn-col-seven-ninths {
+    width: 77.77777778%;
+  }
+
+  .bp1280-wdn-col-eight-ninths,
+  .bp4-wdn-col-eight-ninths {
+    width: 88.88888889%;
+  }
+
+  .bp1280-wdn-col-one-tenth,
+  .bp1280-wdn-grid-set-tenths .wdn-col,
+  .bp4-wdn-col-one-tenth,
+  .bp4-wdn-grid-set-tenths .wdn-col {
+    width: 10%;
+  }
+
+  .bp1280-wdn-col-three-tenths,
+  .bp4-wdn-col-three-tenths {
+    width: 30%;
+  }
+
+  .bp1280-wdn-col-seven-tenths,
+  .bp4-wdn-col-seven-tenths {
+    width: 70%;
+  }
+
+  .bp1280-wdn-col-nine-tenths,
+  .bp4-wdn-col-nine-tenths {
+    width: 90%;
+  }
+
+}
+
+
+// Map 'bp1600' (~1600 px) to 'xl' breakpoint (~1590 px)
+@include mq(xl) {
+
+  .bp1600-wdn-col-full,
+  .bp1600-wdn-grid-set-full .wdn-col {
+    width: 100%;
+  }
+
+  .bp1600-wdn-col-five-tenths,
+  .bp1600-wdn-col-four-eighths,
+  .bp1600-wdn-col-one-half,
+  .bp1600-wdn-col-three-sixths,
+  .bp1600-wdn-col-two-fourths,
+  .bp1600-wdn-grid-set-halves .wdn-col {
+    width: 50%;
+  }
+
+  .bp1600-wdn-col-one-third,
+  .bp1600-wdn-col-three-ninths,
+  .bp1600-wdn-col-two-sixths,
+  .bp1600-wdn-grid-set-thirds .wdn-col {
+    width: 33.33333333%;
+  }
+
+  .bp1600-wdn-col-four-sixths,
+  .bp1600-wdn-col-six-ninths,
+  .bp1600-wdn-col-two-thirds {
+    width: 66.66666667%;
+  }
+
+  .bp1600-wdn-col-one-fourth,
+  .bp1600-wdn-col-two-eighths,
+  .bp1600-wdn-grid-set-fourths .wdn-col {
+    width: 25%;
+  }
+
+  .bp1600-wdn-col-six-eighths,
+  .bp1600-wdn-col-three-fourths {
+    width: 75%;
+  }
+
+  .bp1600-wdn-col-one-fifth,
+  .bp1600-wdn-col-two-tenths,
+  .bp1600-wdn-grid-set-fifths .wdn-col {
+    width: 20%;
+  }
+
+  .bp1600-wdn-col-four-tenths,
+  .bp1600-wdn-col-two-fifths {
+    width: 40%;
+  }
+
+  .bp1600-wdn-col-six-tenths,
+  .bp1600-wdn-col-three-fifths {
+    width: 60%;
+  }
+
+  .bp1600-wdn-col-eight-tenths,
+  .bp1600-wdn-col-four-fifths {
+    width: 80%;
+  }
+
+  .bp1600-wdn-col-one-sixth,
+  .bp1600-wdn-grid-set-sixths .wdn-col {
+    width: 16.66666667%;
+  }
+
+  .bp1600-wdn-col-five-sixths {
+    width: 83.33333333%;
+  }
+
+  .bp1600-wdn-col-one-seventh,
+  .bp1600-wdn-grid-set-sevenths .wdn-col {
+    width: 14.28571429%;
+  }
+
+  .bp1600-wdn-col-two-sevenths {
+    width: 28.57142857%;
+  }
+
+  .bp1600-wdn-col-three-sevenths {
+    width: 42.85714286%;
+  }
+
+  .bp1600-wdn-col-four-sevenths {
+    width: 57.14285714%;
+  }
+
+  .bp1600-wdn-col-five-sevenths {
+    width: 71.42857143%;
+  }
+
+  .bp1600-wdn-col-six-sevenths {
+    width: 85.71428571%;
+  }
+
+  .bp1600-wdn-col-one-eighth,
+  .bp1600-wdn-grid-set-eighths .wdn-col {
+    width: 12.5%;
+  }
+
+  .bp1600-wdn-col-three-eighths {
+    width: 37.5%;
+  }
+
+  .bp1600-wdn-col-five-eighths {
+    width: 62.5%;
+  }
+
+  .bp1600-wdn-col-seven-eighths {
+    width: 87.5%;
+  }
+
+  .bp1600-wdn-col-one-ninth,
+  .bp1600-wdn-grid-set-ninths .wdn-col {
+    width: 11.11111111%;
+  }
+
+  .bp1600-wdn-col-two-ninths {
+    width: 22.22222222%;
+  }
+
+  .bp1600-wdn-col-four-ninths {
+    width: 44.44444444%;
+  }
+
+  .bp1600-wdn-col-five-ninths {
+    width: 55.55555556%;
+  }
+
+  .bp1600-wdn-col-seven-ninths {
+    width: 77.77777778%;
+  }
+
+  .bp1600-wdn-col-eight-ninths {
+    width: 88.88888889%;
+  }
+
+  .bp1600-wdn-col-one-tenth,
+  .bp1600-wdn-grid-set-tenths .wdn-col {
+    width: 10%;
+  }
+
+  .bp1600-wdn-col-three-tenths {
+    width: 30%;
+  }
+
+  .bp1600-wdn-col-seven-tenths {
+    width: 70%;
+  }
+
+  .bp1600-wdn-col-nine-tenths {
+    width: 90%;
+  }
+
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.helpers.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.helpers.scss
@@ -1,0 +1,57 @@
+////////////////////////////////
+// !THEME / DEPRECATED / HELPERS
+////////////////////////////////
+
+
+.centered {
+	float: none !important;
+	margin: 0 auto !important;
+}
+
+.clear {
+	clear: both;
+}
+
+.clear-top {
+  margin-top: 0;
+}
+
+.hidden {
+  display: none;
+}
+
+.wdn-fouc-fix {
+	visibility: hidden;
+}
+
+.wdn-pull-left {
+  float: left;
+}
+
+.wdn-pull-right {
+  float: right;
+}
+
+.wdn-text-hidden {
+  @include sr-only;
+}
+
+.wdn-reponsive-embed {
+  @include ratio;
+}
+
+.wdn-aspect16x9 {
+  @include ratio-16x9
+}
+
+.wdn-aspect3x4 {
+  @include ratio-4x3
+}
+
+.wdn-reponsive-embed embed,
+.wdn-reponsive-embed iframe,
+.wdn-reponsive-embed object,
+.wdn-reponsive-embed video,
+.wdn-reponsive-embed .wdn-responsive-item {
+  @include ratio-child;
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.hero.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.hero.scss
@@ -1,0 +1,162 @@
+/////////////////////////////
+// !THEME / DEPRECATED / HERO
+/////////////////////////////
+
+
+.wdn-hero {
+  background-color: $color-body;
+  display: flex;
+  flex-flow: column wrap;
+}
+
+.wdn-hero .wdn-button {
+  @include mt-6;
+}
+
+.wdn-hero .wdn-button:not(:last-child) {
+  @include mr-3;
+}
+
+.wdn-hero-text-container {
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+  order: 2;
+  padding: 4vh 5.6%;
+  width: 100%;
+}
+
+.wdn-hero-text-container.locate-center {
+  justify-content: center;
+  text-align: center;
+}
+
+.wdn-hero-heading {
+  color: $cream;
+  font-size: #{ms(6)}em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.wdn-hero-initial-line,
+.wdn-hero-impact-line {
+  @include font-sans;
+  text-shadow: 1px 1px 16px fade-out(#000,.5);
+}
+
+.wdn-hero-initial-line {
+  display: block;
+  @include pb-2;
+  font-size: #{ms(-8)}em;
+  letter-spacing: .1em;
+  @include lh-2;
+  @include regular;
+}
+
+.wdn-hero-impact-line {
+  display: inline-block;
+  @include lh-1;
+}
+
+.wdn-hero-impact-line + .wdn-hero-initial-line {
+  @include mt-3;
+}
+
+.wdn-hero-video,
+.wdn-hero-picture {
+  flex-shrink: 0;
+  order: 1;
+  width: 100%;
+}
+
+.wdn-hero-video {
+  display: none;
+  left: 0;
+}
+
+.wdn-hero-picture img,
+.wdn-hero-video video {
+  display: block;
+  width: 100%;
+}
+
+
+// Media Queries
+
+@include mq(md) {
+
+  .wdn-hero {
+    height: #{ms(22)}em;
+    justify-content: center;
+    overflow: hidden;
+    position: relative;
+
+    @supports (object-fit: cover) {
+      height: 56vh;
+      max-height: #{ms(24)}em;
+      min-height: #{ms(22)}em;
+    }
+
+  }
+
+  .wdn-hero video,
+  .wdn-hero img {
+    @include obj-fit-cover;
+  }
+
+  .wdn-hero-text-container {
+    height: 100%;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 1;
+  }
+
+  .wdn-hero-text-container.locate-right {
+  	justify-content: flex-end;
+  }
+
+  .wdn-hero-heading {
+    font-size: #{ms(8)}em;
+  }
+
+  .wdn-hero-initial-line {
+    font-size: #{ms(-10)}em;
+  }
+
+  .wdn-hero-video,
+  .wdn-hero-picture {
+    opacity: .5;
+    overflow: hidden;
+
+    @supports (object-fit: cover) {
+      height: inherit;
+      min-height: #{ms(22)}em;
+    }
+
+  }
+
+  .wdn-hero-video {
+    display: block;
+  }
+
+  .wdn-hero-video ~ .wdn-hero-picture {
+    display: none;
+  }
+
+}
+
+
+@media (min-width: #{ms(30)}em) and (min-height: #{ms(26)}em) {
+
+  .wdn-hero {
+    height: #{ms(24)}em;
+
+    @supports (object-fit: cover) {
+      height: 60vh;
+      max-height: #{ms(26)}em;
+    }
+
+  }
+
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.images.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.images.scss
@@ -1,0 +1,34 @@
+///////////////////////////////
+// !THEME / DEPRECATED / IMAGES
+///////////////////////////////
+
+
+.frame,
+.wdn-frame {
+  @include b-1;
+  border-color: $color-border;
+  @include mb-4;
+  padding: #{ms(-10)}em;
+}
+
+.frame img,
+.wdn-frame img {
+  display: block;
+  max-width: 100%;
+  width: 100%;
+}
+
+.frame figcaption,
+.wdn-frame figcaption {
+  background-color: $color-body-bg;
+  color: $color-light-text;
+  @include font-sans;
+  font-size: #{ms(-2)}em;
+  height: auto;
+  @include p-3;
+}
+
+.frame figcaption *,
+.wdn-frame figcaption * {
+  margin: auto;
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.pagination.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.pagination.scss
@@ -1,0 +1,25 @@
+///////////////////////////////////
+// !THEME / DEPRECATED / PAGINATION
+///////////////////////////////////
+
+
+.wdn_pagination {
+  @include font-sans;
+  font-weight: bold;
+  list-style: none;
+  padding-left: 0;
+}
+
+.wdn_pagination li {
+  display: inline-block;
+}
+
+.wdn_pagination li:not(:last-child) {
+  @include mr-2;
+}
+
+.wdn_pagination li.ellipsis {
+  color: $color-lightest-text;
+}
+
+// .wdn_pagination li.selected {}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.promo-image.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.promo-image.scss
@@ -1,0 +1,81 @@
+////////////////////////////////////
+// !THEME / DEPRECATED / PROMO IMAGE
+////////////////////////////////////
+
+
+.wdn-promo-band {
+	background: $color-body;
+	position: relative;
+}
+
+.wdn-promo-band img,
+.wdn-promo-band video {
+  display: block;
+}
+
+.wdn-promo-container {
+	background-image: linear-gradient(rgba(0,0,0,0) 40%,rgba(0,0,0,.5) 75%,rgba(0,0,0,.3) 100%);
+	bottom: 0;
+	position: absolute;
+	top: 0;
+	width: 100%;
+}
+
+.wdn-promo-content {
+  bottom: 5%;
+  color: #fff;
+  position: absolute;
+  text-align: center;
+  text-shadow: 0 0 10px rgba(0, 0, 0, .5);
+  text-transform: uppercase;
+  width: 100%;
+}
+
+.wdn-promo-content a {
+  text-shadow: none;
+}
+
+.wdn-promo-text {
+  display: block;
+  @include font-sans;
+  font-size: #{ms(6)}em;
+  font-weight: bold;
+  line-height: 1;
+  padding-left: 5.6%;
+  padding-right: 5.6%;
+}
+
+.wdn-promo-text + a {
+  margin-top: 1em;
+}
+
+.wdn-promo-container.wdn-inverse {
+	background-image: linear-gradient(top, rgba(255,255,255,0) 40%,rgba(255,255,255,.5) 75%,rgba(255,255,255,.3) 100%);
+}
+
+.wdn-promo-container.wdn-inverse .wdn-text-over-image {
+	color: $color-body;
+	text-shadow: 0 0 10px rgba(255, 255, 255, .5);
+}
+
+
+@include mq(md) {
+
+	.wdn-promo-content {
+    bottom: 7%;
+  }
+
+  .wdn-promo-text {
+    font-size: #{ms(8)}em;
+  }
+
+}
+
+
+@include mq(lg) {
+
+	.wdn-promo-content {
+    bottom: 10%;
+  }
+
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.quote.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.quote.scss
@@ -1,0 +1,42 @@
+//////////////////////////////
+// !THEME / DEPRECATED / QUOTE
+//////////////////////////////
+
+
+.wdn-quote {
+  font-size: #{ms(2)}em; // 1.33em
+  @include mb-7;
+  margin-left: 0;
+  margin-right: 0;
+  padding-top: #{ms(10)}em; // 4.21em
+  position: relative;
+}
+
+.wdn-quote::before {
+  content: open-quote;
+  font-size: #{ms(14)}em; // 7.49em
+  @include lh-1;
+  position: absolute;
+  top: 0;
+}
+
+.wdn-quote::after {
+  content: close-quote;
+  @include sr-only;
+}
+
+.wdn-quoter {
+  display: block;
+  font-size: #{ms(-2)}em; // .75em
+  font-style: normal;
+  @include mt-4;
+}
+
+.wdn-quoter::before {
+  content: '— '; // em dash (&mdash;) followed by a thin space (&thinsp;)
+}
+
+.quoter-context {
+  display: block;
+  font-style: italic;
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.tables.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.tables.scss
@@ -1,0 +1,103 @@
+///////////////////////////////
+// !THEME / DEPRECATED / TABLES
+///////////////////////////////
+
+
+table {
+  @include bg-transparent;
+  @include font-sans;
+  max-width: 100%;
+  width: 100%;
+}
+
+caption {
+  caption-side: bottom;
+  font-size: #{ms(-2)}em;
+}
+
+thead,
+tbody {
+  @include bb;
+  border-color: $color-border;
+  @include txt-md;
+}
+
+thead th,
+thead td {
+  padding-bottom: #{ms(-4)}rem;
+  vertical-align: bottom;
+}
+
+tbody th,
+tbody td {
+  padding-bottom: #{ms(-4)}rem;
+  padding-top: #{ms(-4)}rem;
+  vertical-align: top;
+}
+
+th:not(:last-child),
+td:not(:last-child) {
+  padding-right: #{ms(2)}rem;
+}
+
+.wdn_responsive_table thead th abbr {
+  border-bottom: none;
+}
+
+
+@include mq(md, max, width) {
+
+  .wdn_responsive_table th,
+  .wdn_responsive_table td {
+    display: block;
+  }
+
+  .wdn_responsive_table thead tr {
+    display: none;
+  }
+
+  .wdn_responsive_table tbody tr:first-child th {
+    border-top-width: 0;
+  }
+
+  .wdn_responsive_table tbody tr:nth-of-type(even) {
+    background-color: transparent;
+  }
+
+  .wdn_responsive_table tbody td {
+  	text-align: left;
+  }
+
+  .wdn_responsive_table tbody td::before {
+    content: attr(data-header);
+    display: block;
+    font-weight: bold;
+  }
+
+  .wdn_responsive_table tbody:empty {
+  	display: none;
+  }
+
+  .wdn_responsive_table tbody:nth-of-type(even) {
+  	background-color: #eee;
+  }
+
+}
+
+
+@include mq(md, max, width) {
+
+  .wdn_responsive_table thead th:not(:first-child) {
+  	text-align: center;
+  }
+
+  .wdn_responsive_table tbody td {
+  	text-align: center;
+  }
+
+  .wdn_responsive_table.flush-left thead th,
+  .wdn_responsive_table.flush-left td {
+  	text-align: left;
+  }
+
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.tabs.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.tabs.scss
@@ -1,0 +1,57 @@
+/////////////////////////////
+// !THEME / DEPRECATED / TABS
+/////////////////////////////
+
+
+.wdn_tabs {
+  display: flex;
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.wdn_tabs li {
+//   background-color: mix($cream, $gray, 98%);
+  background-color: adjust-color($cream, $saturation: -1);
+  border-radius: $roundrect;
+  @include mr-3;
+}
+
+.wdn_tabs li.selected {
+  background-color: #fff;
+  border-radius: $roundrect $roundrect 0 0;
+  box-shadow: 0 1px 1px 1px rgba(0, 0, 0, 0.1);
+  margin-bottom: 0;
+  position: relative;
+}
+
+.wdn_tabs li.selected::after {
+  background-color: #fff;
+  bottom: -3px;
+  content: '';
+  height: 3px;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.wdn_tabs li a {
+  border: 0;
+  display: block;
+  padding: #{ms(-2)}em #{ms(0)}em;
+}
+
+.wdn_tabs li.selected a {
+  @include pb-2;
+}
+
+// old sub-tabs may still exist in markup
+.wdn_tabs li ul {
+  padding: 0 0 0 .4rem;
+}
+
+.wdn_tabs_content {
+  background-color: #fff;
+  box-shadow: 0 1px 1px 1px rgba(0, 0, 0, 0.1);
+  padding: #{ms(6)}em #{ms(4)}em;
+}

--- a/wdn/templates_5.0/scss/deprecated/deprecated.text.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.text.scss
@@ -1,0 +1,57 @@
+/////////////////////////////
+// !THEME / DEPRECATED / TEXT
+/////////////////////////////
+
+
+// Old "brand" font = Tungsten
+// .wdn-brand {}
+// .wdn-heading {}
+// .wdn-impact {}
+// .wdn-brand-caps {}
+
+.wdn-sans-serif {
+  @include font-sans;
+}
+
+.wdn-list-reset {
+  list-style: none;
+  padding-left: 0;
+}
+
+.wdn-sans-caps {
+  @include font-sans;
+  letter-spacing: .02em;
+  line-height: 1.333;
+  text-transform: uppercase;
+}
+
+.wdn-alt-header {
+  @include font-sans;
+  font-size: 1rem;
+  letter-spacing: .02em;
+  line-height: 1.333;
+  text-transform: uppercase;
+}
+
+.wdn-list-header {
+  @include bb;
+  border-color: $color-border;
+  @include font-sans;
+  font-size: 1rem;
+  letter-spacing: .02em;
+  line-height: 1.333;
+  @include pb-1;
+  @include pt-4;
+  text-transform: uppercase;
+}
+
+.wdn-subhead {
+  display: block;
+  font-size: #{ms(-2)}rem; // .75rem
+  @include mb-4;
+  text-transform: uppercase;
+}
+
+.wdn-intro-p {
+  font-size: #{ms(1)}em;
+}


### PR DESCRIPTION
Deprecated styles still need to be added for plugins/widgets and to handle infographics and icons.