### PR TITLE
Fix search params on desktop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 php:
   - 7
 install:
-  - nvm install node
+  - nvm install 8
   - npm install
   # install `pa11y`
   - npm install phantomjs-prebuilt http-server grunt-cli

--- a/tests/Accessibility/phantomjs-axe.js
+++ b/tests/Accessibility/phantomjs-axe.js
@@ -46,7 +46,7 @@ page.open(url, function (status) {
 				}
 			};
 
-			axe.a11yCheck(window.document, options, function (results) {
+			axe.run(window.document, options, function (err, results) {
 				window.callPhantom(results.violations);
 			});
 		});

--- a/wdn/templates_4.1/scripts/search.js
+++ b/wdn/templates_4.1/scripts/search.js
@@ -61,11 +61,15 @@ define(['jquery', 'wdn', 'require', 'navigation'], function($, WDN, require, nav
 
 							for (i = 0; i < allowSearchParams.length; i++) {
 								if (localSearchParams.has(allowSearchParams[i])) {
+									//Used on mobile
 									domSearchForm.append($('<input>', {
 										type: "hidden",
 										name: allowSearchParams[i],
 										value: localSearchParams.get(allowSearchParams[i])
 									}));
+									
+									//Used on desktop with cross frame communication
+									searchFrameAction += '&'+allowSearchParams[i]+'=' + encodeURIComponent(localSearchParams.get(allowSearchParams[i]));
 								}
 							}
 						} else {
@@ -74,11 +78,15 @@ define(['jquery', 'wdn', 'require', 'navigation'], function($, WDN, require, nav
 							for (i = 0; i < localSearchParams.length; i++) {
 								paramPair = localSearchParams[i].split('=');
 								if (allowSearchParams.indexOf(paramPair[0]) >= 0) {
+									//Used on mobile
 									domSearchForm.append($('<input>', {
 										type: "hidden",
 										name: paramPair[0],
 										value: decodeURIComponent(paramPair[1])
 									}));
+									
+									//Used on desktop with cross frame communication
+									searchFrameAction += '&'+paramPair[0]+'=' + encodeURIComponent(paramPair[1]);
 								}
 							}
 						}


### PR DESCRIPTION
Setting the url to search (`u` parameter) was not working at desktop widths. This appears to be due to the fact that the search form is never actually submitted on desktop. Instead, a frame is created via js, then cross frame communication is used to submit changes. Only the search query value is passed via the cross frame communication.

This fixes the issue by altering the initial search frame URL that used to include the parameters.

An example of such a configuration is:

```
<link rel="search" href="https://search.unl.edu/?u=https://admissions.unl.edu/" />
```