### PR TITLE
Closes #1164 - Re-add chat for 5.0

### DIFF
--- a/wdn/templates_5.0/includes/global/nav-toggle-group.html
+++ b/wdn/templates_5.0/includes/global/nav-toggle-group.html
@@ -1,4 +1,4 @@
-<nav class="dcf-nav-toggle-group dcf-pin-bottom dcf-fixed dcf-w-100% dcf-bt-solid dcf-bt-2 unl-bt-scarlet unl-bg-cream unl-font-sans hrjs" role="navigation" aria-label="Navigate, search, log in or chat">
+<nav class="dcf-nav-toggle-group dcf-pin-bottom dcf-fixed dcf-w-100% dcf-bt-solid dcf-bt-2 unl-bt-scarlet unl-bg-cream unl-font-sans hrjs" role="navigation" aria-label="Navigate, search, or log in">
   <button class="dcf-nav-toggle-btn dcf-nav-toggle-btn-menu dcf-d-flex dcf-flex-col dcf-ai-center dcf-jc-center dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent" id="dcf-mobile-toggle-menu" aria-expanded="false">
     <svg class="dcf-txt-sm dcf-mb-1 dcf-h-6 dcf-w-6 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">
       <path d="M23.5 12.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 4.5H.5C.2 4.5 0 4.3 0 4s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 20.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5z"/>
@@ -34,15 +34,4 @@
     </div>
     <div class="dcf-idm-status-logged-in dcf-w-100%"></div>
   </div>
-  <!-- TODO: intergrate with chat widget -->
-  <button class="dcf-nav-toggle-btn dcf-nav-toggle-btn-chat dcf-d-flex dcf-flex-col dcf-ai-center dcf-jc-center dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent" id="dcf-mobile-toggle-chat" aria-expanded="false">
-    <svg class="dcf-txt-sm dcf-mb-1 dcf-h-6 dcf-w-6 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">
-      <path d="M1.4 23.2c-.1 0-.3-.1-.4-.2-.1-.2-.2-.4-.1-.6l2.4-4.8C1.2 15.9 0 13.5 0 10.9 0 5.4 5.4 1 12 1s12 4.4 12 9.9-5.4 9.9-12 9.9c-1.4 0-2.7-.2-4-.6l-6.4 3h-.2zM12 2C5.9 2 1 6 1 10.9c0 2.4 1.2 4.6 3.3 6.3.2.1.2.4.1.6l-1.9 3.9 5.3-2.5c.1-.1.2-.1.4 0 1.2.4 2.5.6 3.9.6 6.1 0 11-4 11-8.9S18.1 2 12 2z"/>
-    </svg>
-    <svg class="dcf-txt-sm dcf-mb-1 dcf-h-6 dcf-w-6 dcf-fill-current dcf-d-none" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">
-      <path d="M20.5 4.2L4.2 20.5c-.2.2-.5.2-.7 0-.2-.2-.2-.5 0-.7L19.8 3.5c.2-.2.5-.2.7 0 .2.2.2.5 0 .7z"/>
-      <path d="M3.5 4.2l16.3 16.3c.2.2.5.2.7 0s.2-.5 0-.7L4.2 3.5c-.2-.2-.5-.2-.7 0-.2.2-.2.5 0 .7z"/>
-    </svg>
-    <span class="dcf-sr-only">Open </span><span class="dcf-nav-toggle-label dcf-bold dcf-uppercase unl-ls-2">Chat</span>
-  </button>
 </nav>

--- a/wdn/templates_5.0/js-src/main.babel.js
+++ b/wdn/templates_5.0/js-src/main.babel.js
@@ -17,5 +17,9 @@ requirejs([
 	//The following plugins initialize on their own and do not need to be passed to the callback
 	'plugins/skipto/skipto.min.js'
 ], function(WDN, require) {
-	//TODO: add UNLchat
+    var unlchat_url = 'https://ucommchat.unl.edu/assets/js';
+    //#UNLCHAT_URL
+    WDN.loadJQuery(function() {
+        require([unlchat_url + '?for=client&version=' + WDN.getHTMLVersion()], function(){});
+    });
 });


### PR DESCRIPTION
#1164 

Bulk of the work occurred in the chat project: https://github.com/unl/VisitorChat/pull/361

This adds the chat initialization right back to where it was in 4.1.  It can possibly be moved later to a plugin of its own (?)