### PR TITLE
Fix band-imagery using deprecated jQuery method

### DIFF
--- a/wdn/templates_5.0/examples/band_imagery.html
+++ b/wdn/templates_5.0/examples/band_imagery.html
@@ -9,7 +9,8 @@
         <h1>Band Imagery, Scroll-Watch Plugin Samples</h1>
         <h2 class="wdn-brand">Scale Sample</h2>
         <div class="wdn-band">
-            <div class="wdn-stretch wdn-scroll-watch" data-lerp="scale" data-lerp-scale-start="#header" data-lerp-scale-end="#maincontent" data-scale-start="1" data-scale-end="1.1">
+            <div class="wdn-stretch wdn-scroll-watch" data-lerp="scale" data-lerp-scale-start="#dcf-header"
+                 data-lerp-scale-end="#dcf-main" data-scale-start="1" data-scale-end="1.25">
                 <figure>
                     <img src="samplecontent/unsplash_525a7e89953d1_1.jpg" alt="Black and white sunset" />
                 </figure>

--- a/wdn/templates_5.0/js-src/band_imagery.js
+++ b/wdn/templates_5.0/js-src/band_imagery.js
@@ -185,7 +185,7 @@ define([
 			imageryUpdate();
 			
 			if (!initd) {
-				$(window).load(imageryUpdate).scroll(function() {
+				$(window).on("load", imageryUpdate).scroll(function() {
 					setTimeout(imageryUpdate, 50);
 				});
 				initd = true;


### PR DESCRIPTION
- replaced outdated ids for band_imagery.html and increased scaling value in scale band-imagery example
- replaced deprecated el.load jquery method to el.on("load", cb)

Fixes #1243 