### PR TITLE
Add trailing slash when constructing siteHomepage

### DIFF
--- a/wdn/templates_5.0/js-src/search.babel.js
+++ b/wdn/templates_5.0/js-src/search.babel.js
@@ -40,7 +40,7 @@ define(['wdn', 'dialog-helper', 'require', 'plugins/body-scroll-lock'], function
 				searchAction = searchOrigin + searchPath,
 				searchFrameAction = searchAction + '?embed=1',
 				allowSearchParams = ['u', 'cx'],  // QS Params allowed by UNL Search app
-				siteHomepage = location.protocol + '//' + location.host,
+				siteHomepage = location.protocol + '//' + location.host + '/',
 				closeNavEvent = new CustomEvent('closeNavigation'),
 				closeIDMOptionsEvent = new CustomEvent('closeDropDownWidget', {detail: {type: 'idm-logged-in'}}),
 				localSearch = getLocalSearch();


### PR DESCRIPTION
The test that compares siteHomepage to www.unl.edu looks for a trailing slash and that's what existed before in 4.1 when siteHomepage was generated by the nav JS