### PR TITLE
Set deprecated WDN Tabs to flex-wrap

### DIFF
--- a/wdn/templates_5.0/scss/deprecated/deprecated.tabs.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.tabs.scss
@@ -5,6 +5,7 @@
 
 .wdn_tabs {
   display: flex;
+  flex-wrap: wrap;
   list-style: none;
   margin-bottom: 0;
   padding-left: 0;


### PR DESCRIPTION
This prevents tabs from being forced onto one row and instead lets them wrap as needed.