### PR TITLE
Fix jQuery UI accordion colors and fonts

### DIFF
--- a/wdn/templates_5.0/js-src/plugins/ui/css/jquery-ui-wdn.scss
+++ b/wdn/templates_5.0/js-src/plugins/ui/css/jquery-ui-wdn.scss
@@ -3,6 +3,16 @@
 
 
 /* UNL WDN jQuery UI overrides */
+.ui-button.ui-state-active:hover,
+.ui-button:active,
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active,
+a.ui-button:active {
+  border: 1px solid #9e0900;
+  background-color: #d00000;
+}
+
 .ui-datepicker,
 .ui-datepicker .ui-datepicker-header .ui-state-hover,
 .ui-datepicker .ui-state-default,

--- a/wdn/templates_5.0/js-src/plugins/ui/css/jquery-ui-wdn.scss
+++ b/wdn/templates_5.0/js-src/plugins/ui/css/jquery-ui-wdn.scss
@@ -3,6 +3,14 @@
 
 
 /* UNL WDN jQuery UI overrides */
+.ui-widget,
+.ui-widget button,
+.ui-widget input,
+.ui-widget select,
+.ui-widget textarea {
+  font-family: inherit;
+}
+
 .ui-button.ui-state-active:hover,
 .ui-button:active,
 .ui-state-active,


### PR DESCRIPTION
- Use framework colors for accordion border and background
- Set `.ui-widget` `font-family` to `inherit` instead of using Arial and Helvetica.