### PR TITLE
Remove vertical-align: middle from deprecated buttons

### DIFF
--- a/wdn/templates_5.0/scss/deprecated/deprecated.forms.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.forms.scss
@@ -138,7 +138,6 @@ main input[type='submit'],
   @include pt-3;
   text-align: center;
   text-transform: uppercase;
-  vertical-align: middle;
 }
 
 main button:focus,


### PR DESCRIPTION
Remove `vertical-align: middle` to vertically align deprecated buttons with current buttons.