### PR TITLE
Update footer markup

### DIFF
--- a/wdn/templates_5.0/includes/global/footer-global-1.html
+++ b/wdn/templates_5.0/includes/global/footer-global-1.html
@@ -1,4 +1,4 @@
-<div class="dcf-footer-stripe dcf-relative">
+<div class="dcf-relative unl-footer-stripe">
   <div class="dcf-wrapper dcf-pt-10 dcf-txt-xs">
     <div class="dcf-d-flex dcf-flex-wrap dcf-jc-between dcf-ai-center">
       <div class="dcf-d-flex dcf-ai-center dcf-mb-7 dcf-mr-7">

--- a/wdn/templates_5.0/includes/global/footer-global-2.html
+++ b/wdn/templates_5.0/includes/global/footer-global-2.html
@@ -37,9 +37,7 @@
           <span class="dcf-uppercase">University</span> <span class="dcf-italic">of</span><span class="unl-institution-title-ls"> </span><span class="dcf-uppercase">Nebraska–Lincoln</span>
         </a>
       </div>
-      <div>
-        Established 1869 &middot; Copyright 2019
-      </div>
+      <small class="dcf-txt-md">Established 1869 &middot; Copyright 2019</small>
     </div>
   </div>
 </div>

--- a/wdn/templates_5.0/scss/components/_components.footer.scss
+++ b/wdn/templates_5.0/scss/components/_components.footer.scss
@@ -9,7 +9,7 @@
 }
 
 
-.unl .dcf-footer-stripe::before {
+.unl-footer-stripe::before {
   background-image: linear-gradient(to top, fade-out($scarlet,1) 3px, $scarlet 3px, $scarlet 5px, fade-out($scarlet,1) 5px);
   content: '';
   height: 5px;

--- a/wdn/templates_5.0/scss/core.tmp.scss
+++ b/wdn/templates_5.0/scss/core.tmp.scss
@@ -42,6 +42,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.typography";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.visibility";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.z-index";
@@ -94,7 +95,6 @@
 // !Objects
 @import "../../../node_modules/dcf/assets/dist/scss/objects/_objects.bleed";
 @import "../../../node_modules/dcf/assets/dist/scss/objects/_objects.grids";
-@import "../../../node_modules/dcf/assets/dist/scss/objects/_objects.lists";
 @import "../../../node_modules/dcf/assets/dist/scss/objects/_objects.media";
 @import "../../../node_modules/dcf/assets/dist/scss/objects/_objects.wrapper";
 @import "objects/_objects.grid";
@@ -113,6 +113,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/components/_components.headings";
 @import "../../../node_modules/dcf/assets/dist/scss/components/_components.icons";
 @import "../../../node_modules/dcf/assets/dist/scss/components/_components.input-groups";
+@import "../../../node_modules/dcf/assets/dist/scss/components/_components.lists";
 @import "../../../node_modules/dcf/assets/dist/scss/components/_components.marks";
 @import "../../../node_modules/dcf/assets/dist/scss/components/_components.modals";
 @import "../../../node_modules/dcf/assets/dist/scss/components/_components.nav-local";
@@ -177,6 +178,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.padding";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.position";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.svg";
+@import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.tables";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.typography";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.visibility";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.z-index";

--- a/wdn/templates_5.0/scss/critical.tmp.scss
+++ b/wdn/templates_5.0/scss/critical.tmp.scss
@@ -42,6 +42,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.typography";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.visibility";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.z-index";

--- a/wdn/templates_5.0/scss/deprecated.tmp.scss
+++ b/wdn/templates_5.0/scss/deprecated.tmp.scss
@@ -42,6 +42,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.typography";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.visibility";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.z-index";

--- a/wdn/templates_5.0/scss/pre.tmp.scss
+++ b/wdn/templates_5.0/scss/pre.tmp.scss
@@ -42,6 +42,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.typography";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.visibility";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.z-index";

--- a/wdn/templates_5.0/scss/print.tmp.scss
+++ b/wdn/templates_5.0/scss/print.tmp.scss
@@ -42,6 +42,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.typography";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.visibility";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.z-index";


### PR DESCRIPTION
- Use `<small>` element for copyright.
- Change `.dcf-footer-stripe` to `.unl-footer-stripe`. The footer stripe is a theme style, not a DCF style.