### PR TITLE
 Update development-only styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /node_modules
 /vagrant/dev/.vagrant
 /wdn/templates_*/css
+/wdn/templates_*/scss/components/_components.dev.scss
 /wdn/templates_*/js/compressed
 /wdn/templates_*/scripts/compressed
 /wdn/templates_*/scripts/js-css/*.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -3043,7 +3043,7 @@
       }
     },
     "dcf": {
-      "version": "git+https://github.com/d-c-n/dcf.git#924940449e8cd6d4abef0ab05d6cd3b594015490",
+      "version": "git+https://github.com/d-c-n/dcf.git#574abb7acbeaa51d4c3b893cbbb9c44156f80c54",
       "from": "git+https://github.com/d-c-n/dcf.git",
       "dev": true,
       "requires": {

--- a/wdn/templates_5.0/scss/components/_components.dev.scss
+++ b/wdn/templates_5.0/scss/components/_components.dev.scss
@@ -156,25 +156,3 @@
 //   mask: url('../images/noisy.png');
 //   mask: url('../images/old-map.png');
 }
-
-
-
-
-// .unl-heading-ornament::before,
-.unl-heading-ornament::after {
-  background-color: $color-heading;
-  content: '';
-  display: block;
-  @include w-6;
-}
-
-// .unl-heading-ornament::before {
-//   height: 2px;
-//   margin-bottom: 1rem;
-// }
-
-.unl-heading-ornament::after {
-  height: 2px;
-  margin-left: .03em;
-  margin-top: 1rem;
-}

--- a/wdn/templates_5.0/scss/components/_components.dev.scss
+++ b/wdn/templates_5.0/scss/components/_components.dev.scss
@@ -3,28 +3,6 @@
 ////////////////////////////
 
 
-// core
-.unl .dcf-modal-overlay {
-  transition: none;
-  z-index: 100149;
-}
-
-.unl .dcf-modal-overlay[aria-hidden="true"] {
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 300ms ease-out, visibility 0ms 400ms;
-    visibility: hidden;
-}
-
-.unl .dcf-modal-overlay[aria-hidden="false"] {
-    opacity: 1;
-    pointer-events: auto;
-    transition: opacity 200ms ease-out;
-    visibility: visible;
-}
-// core
-
-
 .unl-stripes::after {
   background-image: repeating-linear-gradient($diagonal1, fade-out($color-body,.5), fade-out($color-body,.5) 1px, transparent 1px, transparent 2px);
   content: '';

--- a/wdn/templates_5.0/scss/components/_components.headings.scss
+++ b/wdn/templates_5.0/scss/components/_components.headings.scss
@@ -37,7 +37,7 @@
 
 
 .unl-heading-ornament::after {
-  background-color: $color-heading;
+  background-color: currentColor;
   content: '';
   display: block;
   height: 2px;

--- a/wdn/templates_5.0/scss/components/_components.headings.scss
+++ b/wdn/templates_5.0/scss/components/_components.headings.scss
@@ -34,3 +34,14 @@
   @include mb-3;
   text-transform: uppercase;
 }
+
+
+.unl-heading-ornament::after {
+  background-color: $color-heading;
+  content: '';
+  display: block;
+  height: 2px;
+  margin-left: .03em;
+  margin-top: 1rem;
+  @include w-6;
+}

--- a/wdn/templates_5.0/scss/core.tmp.scss
+++ b/wdn/templates_5.0/scss/core.tmp.scss
@@ -16,7 +16,9 @@
 @import "variables/_variables.angles";
 @import "variables/_variables.borders";
 @import "variables/_variables.colors";
+@import "variables/_variables.easing";
 @import "variables/_variables.sizing";
+@import "variables/_variables.timing";
 
 
 // !Mixins

--- a/wdn/templates_5.0/scss/critical.tmp.scss
+++ b/wdn/templates_5.0/scss/critical.tmp.scss
@@ -16,7 +16,9 @@
 @import "variables/_variables.angles";
 @import "variables/_variables.borders";
 @import "variables/_variables.colors";
+@import "variables/_variables.easing";
 @import "variables/_variables.sizing";
+@import "variables/_variables.timing";
 
 
 // !Mixins

--- a/wdn/templates_5.0/scss/deprecated.tmp.scss
+++ b/wdn/templates_5.0/scss/deprecated.tmp.scss
@@ -16,7 +16,9 @@
 @import "variables/_variables.angles";
 @import "variables/_variables.borders";
 @import "variables/_variables.colors";
+@import "variables/_variables.easing";
 @import "variables/_variables.sizing";
+@import "variables/_variables.timing";
 
 
 // !Mixins

--- a/wdn/templates_5.0/scss/pre.tmp.scss
+++ b/wdn/templates_5.0/scss/pre.tmp.scss
@@ -16,7 +16,9 @@
 @import "variables/_variables.angles";
 @import "variables/_variables.borders";
 @import "variables/_variables.colors";
+@import "variables/_variables.easing";
 @import "variables/_variables.sizing";
+@import "variables/_variables.timing";
 
 
 // !Mixins

--- a/wdn/templates_5.0/scss/print.tmp.scss
+++ b/wdn/templates_5.0/scss/print.tmp.scss
@@ -16,7 +16,9 @@
 @import "variables/_variables.angles";
 @import "variables/_variables.borders";
 @import "variables/_variables.colors";
+@import "variables/_variables.easing";
 @import "variables/_variables.sizing";
+@import "variables/_variables.timing";
 
 
 // !Mixins

--- a/wdn/templates_5.0/scss/variables/_variables.easing.scss
+++ b/wdn/templates_5.0/scss/variables/_variables.easing.scss
@@ -1,0 +1,7 @@
+//////////////////////////////
+// !THEME / VARIABLES / EASING
+//////////////////////////////
+
+
+$easing-fade-in: ease-out;
+$easing-fade-out: ease-out;

--- a/wdn/templates_5.0/scss/variables/_variables.timing.scss
+++ b/wdn/templates_5.0/scss/variables/_variables.timing.scss
@@ -1,0 +1,7 @@
+//////////////////////////////
+// !THEME / VARIABLES / TIMING
+//////////////////////////////
+
+
+$timing-fade-in: 200ms;
+$timing-fade-out: 400ms;


### PR DESCRIPTION
- Add theme easing and timing variables to account for DCF update
- Ignore development-only styles
- Remove temp modal styles now found in DCF core
- Move heading ornament from ‘dev’ to ‘headings’ and use `currentColor`