### PR TITLE
Update DCF and lazy load images on debug page

### DIFF
--- a/debug.shtml
+++ b/debug.shtml
@@ -270,7 +270,7 @@
       	</div>
       </div>
 
-      <div class="dcf-bleed dcf-bt dcf-bb" style="">
+      <div class="dcf-bleed">
         <div class="dcf-wrapper">
           <div class="dcf-relative dcf-grid dcf-col-gap-vw dcf-row-gap-4 dcf-pt-9 dcf-pb-9">
             <div class="dcf-2nd unl-ftd-person-tsr-body">
@@ -280,10 +280,15 @@
               <a class="dcf-btn dcf-btn-secondary" href="#" role="button">Meet Kylie</a>
             </div>
             <div class="dcf-1st unl-ftd-person-tsr-img">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Kylie Tucker">
               </div>
@@ -292,7 +297,7 @@
       	</div>
       </div>
 
-      <div class="dcf-bleed dcf-bb" style="">
+      <div class="dcf-bleed">
         <div class="dcf-wrapper">
           <div class="dcf-relative dcf-grid dcf-col-gap-vw dcf-row-gap-4 dcf-pt-9 dcf-pb-9">
             <div class="dcf-2nd unl-ftd-person-tsr-body">
@@ -302,10 +307,15 @@
               <a class="dcf-btn dcf-btn-secondary" href="#" role="button">See How Valerie Got There</a>
             </div>
             <div class="dcf-1st unl-ftd-person-tsr-img">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Valerie Jones">
               </div>
@@ -314,7 +324,7 @@
       	</div>
       </div>
 
-      <div class="dcf-bleed dcf-bb" style="">
+      <div class="dcf-bleed">
         <div class="dcf-wrapper">
           <div class="dcf-relative dcf-grid dcf-col-gap-vw dcf-row-gap-4 dcf-pt-9 dcf-pb-9">
             <div class="dcf-2nd unl-ftd-person-tsr-body">
@@ -324,10 +334,15 @@
               <a class="dcf-btn dcf-btn-secondary" href="#" role="button">Meet Eartha</a>
             </div>
             <div class="dcf-1st unl-ftd-person-tsr-img">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Eartha Jean Johnson">
               </div>
@@ -439,8 +454,8 @@
 
 
       <div class="dcf-pt-9 dcf-pb-10">
-        <div class="dcf-grid dcf-col-gap-vw dcf-row-gap-6">
-          <div class="dcf-2nd dcf-col-67%-end@sm dcf-as-center">
+        <div class="dcf-grid dcf-col-gap-vw dcf-row-gap-4">
+          <div class="dcf-2nd dcf-col-100% dcf-col-67%-end@sm dcf-as-center">
             <h2 class="dcf-mb-0 dcf-txt-h4"><a class="dcf-txt-decor-hover" href="#">Charles O’Connor</a></h2>
             <div class="dcf-mt-1 dcf-mb-5 dcf-lh-3 dcf-italic unl-dark-gray">
               Dean
@@ -449,10 +464,15 @@
             <a class="dcf-btn dcf-btn-secondary" href="#" role="button">Full Bio</a>
       	  </div>
           <div class="dcf-1st dcf-col-50%-start dcf-col-33%-start@sm">
-            <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+            <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
               <img
                 class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                data-src="https://via.placeholder.com/400x400"
+                data-sizes=""
+                data-src="https://via.placeholder.com/200x200"
+                data-srcset="https://via.placeholder.com/200x200 200w,
+                             https://via.placeholder.com/400x400 400w,
+                             https://via.placeholder.com/600x600 600w,
+                             https://via.placeholder.com/800x800 800w"
                 src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                 alt="Placeholder for photo of Charles O’Connor">
             </div>
@@ -479,10 +499,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Director of Communications and External Relations</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Kathe Andersen">
               </div>
@@ -494,10 +519,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Information Technology Services Manager</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of David Bagby">
               </div>
@@ -509,10 +539,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Administrative Technician</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Allison Casey">
               </div>
@@ -524,10 +559,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Assistant to the Dean</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Rachel Danay">
               </div>
@@ -539,10 +579,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Assistant Director of Advising</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Sara Fedderson">
               </div>
@@ -554,10 +599,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Assistant Director of Recruitment</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Matthew Knight">
               </div>
@@ -569,10 +619,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Systems Coordinator</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Joseph Morris">
               </div>
@@ -584,10 +639,15 @@
               <div class="dcf-mt-1 dcf-txt-xs dcf-lh-3 dcf-italic unl-dark-gray">Digital Arts Support Technician</div>
             </div>
             <div class="dcf-1st dcf-mb-3">
-              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle">
+              <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-                  data-src="https://via.placeholder.com/400x400"
+                  data-sizes=""
+                  data-src="https://via.placeholder.com/200x200"
+                  data-srcset="https://via.placeholder.com/200x200 200w,
+                               https://via.placeholder.com/400x400 400w,
+                               https://via.placeholder.com/600x600 600w,
+                               https://via.placeholder.com/800x800 800w"
                   src="data:image/gif;base64,R0lGODlhAQABAAAAADs="
                   alt="Placeholder for photo of Michael Reinmiller">
               </div>
@@ -611,7 +671,7 @@
                 <img
                   class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
                   data-sizes="(min-width: 41.956em) 43vw, 88vw"
-                  data-src="wdn/templates_5.0/images/dev/140903-life-498-sm-min.jpg 284w"
+                  data-src="wdn/templates_5.0/images/dev/150815-commencement-324-sm-min.jpg 284w"
                   data-srcset="wdn/templates_5.0/images/dev/140903-life-498-sm-min.jpg 284w,
                           wdn/templates_5.0/images/dev/140903-life-498-md-min.jpg 505w,
                           wdn/templates_5.0/images/dev/140903-life-498-lg-min.jpg 898w,
@@ -631,7 +691,7 @@
           <div class="dcf-float-left dcf-h-10 dcf-w-10 dcf-mt-1 dcf-mr-4 dcf-mb-4 dcf-ratio dcf-ratio-1x1 dcf-circle unl-clip-circle">
             <img
               class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
-              data-sizes="(min-width: 41.956em) 43vw, 88vw"
+              data-sizes="5.62em"
               data-src="wdn/templates_5.0/images/dev/160813-commencement-563-sm-min.jpg 284w"
               data-srcset="wdn/templates_5.0/images/dev/160813-commencement-563-sm-min.jpg 284w,
                       wdn/templates_5.0/images/dev/160813-commencement-563-md-min.jpg 505w,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3130,7 +3130,7 @@
       }
     },
     "dcf": {
-      "version": "git+https://github.com/d-c-n/dcf.git#382731c036bce4b029269dfed57a38218f0852f2",
+      "version": "git+https://github.com/d-c-n/dcf.git#3713aa28c239dca0b4c959861ab9e8f6e6f87ce9",
       "from": "git+https://github.com/d-c-n/dcf.git",
       "dev": true,
       "requires": {
@@ -4826,8 +4826,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4851,15 +4850,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4876,22 +4873,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5022,8 +5016,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5037,7 +5030,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5054,7 +5046,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5063,15 +5054,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5092,7 +5081,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5188,8 +5176,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5203,7 +5190,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5299,8 +5285,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5342,7 +5327,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5364,7 +5348,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5413,15 +5396,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
- Update DCF (includes [additions](https://github.com/d-c-n/dcf/pull/248) to the [lazy-load JavaScript](https://github.com/d-c-n/dcf/blob/master/assets/src/js/app/common/dcf-lazyLoad.js) to calculate image size and fill empty `data-sizes` attribute).
- Lazy load images on the debug page