### PR TITLE
Use 'loading' attribute to lazy load images

### DIFF
--- a/debug.shtml
+++ b/debug.shtml
@@ -130,6 +130,7 @@
         <div class="dcf-mb-6 dcf-ratio dcf-ratio-16x9 unl-frame-quad">
           <img
             class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+            loading="eager"
             sizes="(min-width: 41.956em) 43vw, 88vw"
             srcset="wdn/templates_5.0/images/dev/150821-tunnel-325-sm-min.jpg 284w,
                     wdn/templates_5.0/images/dev/150821-tunnel-325-md-min.jpg 505w,
@@ -255,7 +256,8 @@
             <div class="dcf-as-center">
               <div class="dcf-ratio dcf-ratio-16x9 unl-frame-quad unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes="(min-width: 41.956em) 43vw, 88vw"
                   data-src="wdn/templates_5.0/images/dev/150815-commencement-324-sm-min.jpg 284w"
                   data-srcset="wdn/templates_5.0/images/dev/150815-commencement-324-sm-min.jpg 284w,
@@ -282,7 +284,8 @@
             <div class="dcf-1st unl-ftd-person-tsr-img">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -309,7 +312,8 @@
             <div class="dcf-1st unl-ftd-person-tsr-img">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -336,7 +340,8 @@
             <div class="dcf-1st unl-ftd-person-tsr-img">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -466,7 +471,8 @@
           <div class="dcf-1st dcf-col-50%-start dcf-col-33%-start@sm">
             <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
               <img
-                class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                loading="lazy"
                 data-sizes=""
                 data-src="https://via.placeholder.com/200x200"
                 data-srcset="https://via.placeholder.com/200x200 200w,
@@ -501,7 +507,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -521,7 +528,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -541,7 +549,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -561,7 +570,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -581,7 +591,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -601,7 +612,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -621,7 +633,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -641,7 +654,8 @@
             <div class="dcf-1st dcf-mb-3">
               <div class="dcf-ratio dcf-ratio-1x1 dcf-circle unl-frame-circle unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes=""
                   data-src="https://via.placeholder.com/200x200"
                   data-srcset="https://via.placeholder.com/200x200 200w,
@@ -669,7 +683,8 @@
             <div class="dcf-as-center">
               <div class="dcf-ratio dcf-ratio-16x9 unl-frame-quad unl-bg-light-gray">
                 <img
-                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+                  class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+                  loading="lazy"
                   data-sizes="(min-width: 41.956em) 43vw, 88vw"
                   data-src="wdn/templates_5.0/images/dev/150815-commencement-324-sm-min.jpg 284w"
                   data-srcset="wdn/templates_5.0/images/dev/140903-life-498-sm-min.jpg 284w,
@@ -690,7 +705,8 @@
           <h2 class="dcf-txt-h4">Malesuada Pellentesque</h2>
           <div class="dcf-float-left dcf-h-10 dcf-w-10 dcf-mt-1 dcf-mr-4 dcf-mb-4 dcf-ratio dcf-ratio-1x1 dcf-circle unl-clip-circle">
             <img
-              class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100% dcf-lazy-img"
+              class="dcf-ratio-child dcf-obj-fit-cover dcf-h-100% dcf-w-100%"
+              loading="lazy"
               data-sizes="5.62em"
               data-src="wdn/templates_5.0/images/dev/160813-commencement-563-sm-min.jpg 284w"
               data-srcset="wdn/templates_5.0/images/dev/160813-commencement-563-sm-min.jpg 284w,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3130,7 +3130,7 @@
       }
     },
     "dcf": {
-      "version": "git+https://github.com/d-c-n/dcf.git#3713aa28c239dca0b4c959861ab9e8f6e6f87ce9",
+      "version": "git+https://github.com/d-c-n/dcf.git#070b4dedeb97b56698e618d91702acfd8fd279cb",
       "from": "git+https://github.com/d-c-n/dcf.git",
       "dev": true,
       "requires": {

--- a/wdn/templates_5.0/js-src/lazy-load.babel.js
+++ b/wdn/templates_5.0/js-src/lazy-load.babel.js
@@ -1,6 +1,6 @@
 require (['dcf-lazyLoad'], (LazyLoad) => {
 
-  const images = document.querySelectorAll('.dcf-lazy-img');
+  const images = document.querySelectorAll('[loading=lazy]');
   const observerConfig = {
   	// extend intersection root margin by 50px to start intersection earlier by 50px
   	rootMargin: '0px 0px 50px 0px',


### PR DESCRIPTION
- Update DCF.
- Use `loading` attribute instead of `dcf-lazy-img` class for lazy loading.