### PR TITLE
Update deprecated bands background colors

### DIFF
--- a/wdn/templates_5.0/scss/deprecated/deprecated.bands.scss
+++ b/wdn/templates_5.0/scss/deprecated/deprecated.bands.scss
@@ -27,12 +27,9 @@
   @include bg-lightest;
 }
 
-.wdn-light-triad-band {
-  @include bg-lighter;
-}
-
+.wdn-light-triad-band,
 .wdn-light-complement-band {
-  @include bg-light;
+  @include bg-lighter;
 }
 
 .wdn-inner-wrapper {


### PR DESCRIPTION
Lighten `.wdn-light-complement-band` `background-color` for color contrast compliant links.