### PR TITLE
Revert some <details>, <summary> styles

### DIFF
--- a/wdn/templates_5.0/scss/elements/_elements.details-summary.scss
+++ b/wdn/templates_5.0/scss/elements/_elements.details-summary.scss
@@ -21,37 +21,11 @@
 
 
 .unl summary {
-  align-items: center;
   cursor: pointer;
-  display: flex;
-  flex-flow: row nowrap;
   @include font-sans;
   @include txt-h6;
-  justify-content: space-between;
   letter-spacing: -.03em;
   @include lh-3;
-  list-style: none;
-}
-
-
-.unl summary::-webkit-details-marker {
-  display: none;
-}
-
-
-.unl summary::after {
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='#{$scarlet}' d='M23 11H13V1c0-.6-.4-1-1-1s-1 .4-1 1v10H1c-.6 0-1 .4-1 1s.4 1 1 1h10v10c0 .6.4 1 1 1s1-.4 1-1V13h10c.6 0 1-.4 1-1s-.4-1-1-1z' /%3E%3C/svg%3E") 100% no-repeat;
-  content: '';
-  flex-shrink: 0;
-  @include h-4;
-  @include ml-5;
-  transition: transform .2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  @include w-4;
-}
-
-
-.unl details[open] summary::after {
-  transform: rotate(45deg);
 }
 
 


### PR DESCRIPTION
I discovered that the styles and interactions for the custom marker are broken in Safari. 

- The marker is displayed below the summary instead of to the right of it.
- A user is forced to focus on another element before the marker is rotated from ‘+’ to ‘×’.

I’m reverting to browser defaults for consistency.