### PR TITLE
Remove monthwidet date hover UI (JS & CSS)

### DIFF
--- a/wdn/templates_5.0/js-src/js-css/monthwidget.scss
+++ b/wdn/templates_5.0/js-src/js-css/monthwidget.scss
@@ -50,28 +50,6 @@
   outline: 2px solid $scarlet;
 }
 
-.wp-calendar td .eventContainer {
-  box-shadow: 0 1px 2px rgba(0,0,0,.25), 0 1px 10px rgba(0,0,0,.1);
-  left: 50%;
-  top: calc(100% - 3px);
-  transform: translateX(calc(-#{ms(4)}em - #{ms(-6)}em));
-  width: #{ms(19)}em;
-  word-break: normal;
-}
-
-.wp-calendar td .eventContainer::before {
-  border-color: $scarlet transparent;
-  border-width: 0 $length-em-1 $length-em-1 $length-em-1;
-  border-style: solid;
-  content: '';
-  display: block;
-  height: 0;
-  left: $length-em-6;
-  position: absolute;
-  top: -2px;
-  transform: translateY(-100%);
-}
-
 .wp-calendar .monthvalue a:focus,
 .wp-calendar .monthvalue a:hover,
 .wp-calendar .yearvalue a:focus,
@@ -79,17 +57,6 @@
 .wp-calendar td .eventContainer a:focus,
 .wp-calendar td .eventContainer a:hover {
   text-decoration: underline;
-}
-
-.wp-calendar td .eventContainer.pos2 {
-  left: auto;
-  right: 50%;
-  transform: translateX(calc(#{ms(4)}em + #{ms(-6)}em));
-}
-
-.wp-calendar td .eventContainer.pos2::before {
-  left: auto;
-  right: $length-em-6;
 }
 
 .wp-calendar caption {

--- a/wdn/templates_5.0/js-src/monthwidget.js
+++ b/wdn/templates_5.0/js-src/monthwidget.js
@@ -50,55 +50,6 @@ define([
 
     $days.wrapInner('<div/>');
 
-    $days.each(function() {
-      var el = $(this).get(0);
-
-      hoverintent(el,
-      function() {
-        var infoBox = $('.eventContainer', this);
-        if (infoBox.length) {
-          infoBox.show();
-        } else {
-          infoBox = $('<div class="eventContainer dcf-absolute dcf-z-1 dcf-pt-3 dcf-pb-3 dcf-txt-left dcf-bg-white dcf-bt-3 dcf-bt-solid unl-bt-scarlet"><div class="eventBox">Loading...</div></div>');
-          infoBox.appendTo($('div:first', this));
-          if ($(this).position().left + $(this).width() + infoBox.width() >= $($container[0].offsetParent).outerWidth()) {
-            infoBox.addClass('pos2');
-          }
-          var eventBox = $('.eventBox', this);
-          var regex = /\d{4}\/\d{1,2}\/\d{1,2}/;
-          var date = moment(regex.exec($('a', this)[0].href)[0]);
-          $.ajax({
-            url: $('a', this)[0].href + '?format=xml',
-            dataType: 'xml',
-            success: function(data) {
-              var eventTitle = $('EventTitle', data);
-              var eventWebPageTitle = $('Title', data);
-              var eventURL = [];
-              eventBox.empty();
-
-              eventWebPageTitle.each(function() {
-                var $this = $(this);
-                if ($this.text() == 'Event Instance URL') {
-                  eventURL.push($this.next().text());
-                }
-              });
-              $.each(eventURL, function(i, url) {
-                eventBox.append('<a class="dcf-d-block dcf-mr-6 dcf-ml-6 dcf-pt-1 dcf-pb-1 dcf-txt-xs dcf-lh-2" href="' + url + '">' + eventTitle.eq(i).text() + '</a>');
-              });
-            },
-            error: function() {
-              eventBox.html('Error loading results.');
-            }
-          });
-        }
-        return false;
-      }, function() {
-        $('.eventContainer', this).hide();
-        return false;
-      });
-
-    });
-
     $container.show();
   };
 

--- a/wdn/templates_5.0/js-src/monthwidget.js
+++ b/wdn/templates_5.0/js-src/monthwidget.js
@@ -1,60 +1,60 @@
 define([
-	'wdn',
-	'jquery',
-	'moment',
-	'plugins/hoverIntent/hoverintent',
-	'css!js-css/monthwidget'
+  'wdn',
+  'jquery',
+  'moment',
+  'plugins/hoverIntent/hoverintent',
+  'css!js-css/monthwidget'
 ], function(WDN, $, moment) {
-	var initd = true;
+  var initd = true;
 
-	var getLocalEventSettings = function() {
-		var $eventLink = $('link[rel=events]'),
-			eventParams = WDN.getPluginParam('events');
+  var getLocalEventSettings = function() {
+    var $eventLink = $('link[rel=events]'),
+    eventParams = WDN.getPluginParam('events');
 
-		if ($eventLink.length) {
-			return {
-				href: $eventLink[0].href,
-				title: $eventLink[0].title
-			};
-		}
+    if ($eventLink.length) {
+      return {
+        href: $eventLink[0].href,
+        title: $eventLink[0].title
+      };
+    }
 
-		return eventParams || {};
-	},
-	container = '#monthwidget',
-	defaultCal = 'https://events.unl.edu/';
+    return eventParams || {};
+  },
+  container = '#monthwidget',
+  defaultCal = 'https://events.unl.edu/';
 
-	var display = function(data, config) {
-		var $container = $(config.container);
-		$container.hide().html(data);
-		$('#prev_month', $container).removeAttr('id').addClass('prev');
-		$('#next_month', $container).removeAttr('id').addClass('next');
+  var display = function(data, config) {
+    var $container = $(config.container);
+    $container.hide().html(data);
+    $('#prev_month', $container).removeAttr('id').addClass('prev');
+    $('#next_month', $container).removeAttr('id').addClass('next');
 
-		var now = new Date(), today = now.getDate();
-		var month = $('span.monthvalue a', $container).attr('href');
-		month = month.substr(month.length - 3, 2);
-		if (month.charAt(0) == '/') {
-			month = month.substr(1);
-		}
+    var now = new Date(), today = now.getDate();
+    var month = $('span.monthvalue a', $container).attr('href');
+    month = month.substr(month.length - 3, 2);
+    if (month.charAt(0) == '/') {
+      month = month.substr(1);
+    }
 
-		var $days = $('tbody td', $container).not('.prev, .next');
+    var $days = $('tbody td', $container).not('.prev, .next');
 
-		if (month - 1 == now.getMonth()) {
-			$days.each(function() {
-				var $this = $(this);
-				if ($this.text() == today) {
-					$this.addClass('today');
-					return false;
-				}
-			});
-		}
+    if (month - 1 == now.getMonth()) {
+      $days.each(function() {
+        var $this = $(this);
+        if ($this.text() == today) {
+          $this.addClass('today');
+          return false;
+        }
+      });
+    }
 
-		$days.wrapInner('<div/>');
+    $days.wrapInner('<div/>');
 
     $days.each(function() {
       var el = $(this).get(0);
 
       hoverintent(el,
-			function() {
+      function() {
         var infoBox = $('.eventContainer', this);
         if (infoBox.length) {
           infoBox.show();
@@ -92,46 +92,45 @@ define([
           });
         }
         return false;
-			}, function() {
-				$('.eventContainer', this).hide();
-				return false;
-			});
+      }, function() {
+        $('.eventContainer', this).hide();
+        return false;
+      });
 
     });
 
-		$container.show();
-	};
+    $container.show();
+  };
 
-	var setup = function(config) {
-		var localSettings = getLocalEventSettings(),
-		defaultConfig = {
-			url: localSettings.href || defaultCal,
-			container: container
-		},
-		localConfig = $.extend({}, defaultConfig, config);
+  var setup = function(config) {
+    var localSettings = getLocalEventSettings(),
+    defaultConfig = {
+      url: localSettings.href || defaultCal,
+      container: container
+    },
+    localConfig = $.extend({}, defaultConfig, config);
 
-		// ensure that the URL we are about to use is forced into an https:// protocol. (add https if it starts with //)
-        if (localConfig.url && localConfig.url.match(/^\/\//)) {
-            localConfig.url = 'https:' + localConfig.url;
-        } else if (localConfig.url && localConfig.url.match(/^http:\/\//)) {
-            localConfig.url = localConfig.url.replace('http://', 'https://');
-        }
+    // ensure that the URL we are about to use is forced into an https:// protocol. (add https if it starts with //)
+    if (localConfig.url && localConfig.url.match(/^\/\//)) {
+      localConfig.url = 'https:' + localConfig.url;
+    } else if (localConfig.url && localConfig.url.match(/^http:\/\//)) {
+      localConfig.url = localConfig.url.replace('http://', 'https://');
+    }
 
-		if (localConfig.url && $(localConfig.container).length) {
-			$.get(localConfig.url + '?monthwidget&format=hcalendar', function(data) {
-					display(data, localConfig);
-				}
-			);
-		}
-	};
+    if (localConfig.url && $(localConfig.container).length) {
+      $.get(localConfig.url + '?monthwidget&format=hcalendar', function(data) {
+        display(data, localConfig);
+      });
+    }
+  };
 
-	return {
-		initialize : function(config) {
-			$(function() {
-				setup(config);
-			});
-		},
+  return {
+    initialize : function(config) {
+      $(function() {
+        setup(config);
+      });
+    },
 
-		setup : setup,
-	};
+    setup : setup,
+  };
 });


### PR DESCRIPTION
Remove monthwidget user interface that showed a date's events on hover. This content could not be accessed on touchscreen devices and, anecdotally, numerous users told me that they weren't even aware of the hover content. Removing this user interface also eliminates the Safari bug where the caption would move to the bottom of the calendar after hovering over a date.

Closes #1316