### PR TITLE
Add legacy hero CSS

### DIFF
--- a/wdn/templates_5.0/scss/components/_components.heroes-legacy.scss
+++ b/wdn/templates_5.0/scss/components/_components.heroes-legacy.scss
@@ -1,0 +1,62 @@
+///////////////////////////////////////
+// !THEME / COMPONENTS / HEROES: LEGACY
+///////////////////////////////////////
+
+
+// Legacy hero
+.unl-hero-legacy .dcf-breadcrumbs {
+  display: none;
+}
+
+.unl-hero-legacy .dcf-hero-group-1 {
+  padding: $length-em-6 $length-vw-2;
+}
+
+.unl-hero-legacy .dcf-page-title {
+  @include mb-3;
+}
+
+
+@include mq(sm, max, width) {
+
+  .unl-hero-legacy {
+    flex-direction: column-reverse;
+  }
+
+}
+
+@include mq(sm, min, width) {
+
+  .unl-hero-legacy {
+    align-items: center;
+    height: #{ms(28)}vh;
+    max-height: #{ms(24)}em;
+    position: relative;
+  }
+
+  .unl-hero-legacy .dcf-hero-group-1 {
+    position: relative;
+    z-index: 1;
+  }
+
+  .unl-hero-legacy .dcf-hero-group-2 {
+    display: flex;
+    height: #{ms(28)}vh;
+    left: 0;
+    max-height: #{ms(24)}em;
+    opacity: .5;
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
+}
+
+@include mq(md, min, width) {
+
+  .unl .unl-hero-legacy .dcf-page-title h1 {
+    font-size: #{ms(7)}em;
+  }
+
+}

--- a/wdn/templates_5.0/scss/core.tmp.scss
+++ b/wdn/templates_5.0/scss/core.tmp.scss
@@ -40,9 +40,11 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.media-queries";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-fit";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-position";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.opacity";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.order";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.overflow";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.pointer-events";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";
@@ -141,6 +143,7 @@
 @import "components/_components.header";
 @import "components/_components.headings";
 @import "components/_components.heroes-default";
+@import "components/_components.heroes-legacy";
 @import "components/_components.heroes-notch-stripe";
 @import "components/_components.heroes";
 @import "components/_components.icons";
@@ -179,9 +182,11 @@
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.margins";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.object-fit";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.object-position";
+@import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.opacity";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.order";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.overflow";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.padding";
+@import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.pointer-events";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.position";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.svg";
 @import "../../../node_modules/dcf/assets/dist/scss/utilities/_utilities.tables";

--- a/wdn/templates_5.0/scss/critical.tmp.scss
+++ b/wdn/templates_5.0/scss/critical.tmp.scss
@@ -40,9 +40,11 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.media-queries";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-fit";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-position";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.opacity";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.order";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.overflow";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.pointer-events";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";

--- a/wdn/templates_5.0/scss/deprecated.tmp.scss
+++ b/wdn/templates_5.0/scss/deprecated.tmp.scss
@@ -40,9 +40,11 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.media-queries";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-fit";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-position";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.opacity";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.order";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.overflow";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.pointer-events";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";

--- a/wdn/templates_5.0/scss/pre.tmp.scss
+++ b/wdn/templates_5.0/scss/pre.tmp.scss
@@ -40,9 +40,11 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.media-queries";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-fit";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-position";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.opacity";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.order";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.overflow";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.pointer-events";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";

--- a/wdn/templates_5.0/scss/print.tmp.scss
+++ b/wdn/templates_5.0/scss/print.tmp.scss
@@ -40,9 +40,11 @@
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.media-queries";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-fit";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.object-position";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.opacity";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.order";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.overflow";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.padding";
+@import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.pointer-events";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.position";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.svg";
 @import "../../../node_modules/dcf/assets/dist/scss/mixins/_mixins.tables";


### PR DESCRIPTION
Add styles for legacy (4.1-style) heroes. 

Documentation will need to be added to show which utility classes are required to complete the legacy hero layout.