### PR TITLE
Remove deprecated.css link from head include files

### DIFF
--- a/wdn/templates_5.0/includes/global/head-2-local.html
+++ b/wdn/templates_5.0/includes/global/head-2-local.html
@@ -3,11 +3,9 @@
 <script>document.documentElement.classList.remove("no-js");</script>
 <link id="unl-css-core" rel="preload" href="/wdn/templates_5.0/css/core.css?dep=$DEP_VERSION$" as="style" onload="this.onload=null;this.rel='stylesheet';">
 <link rel="preload" href="https://cloud.typography.com/7717652/6968572/css/fonts.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<link rel="preload" href="/wdn/templates_5.0/css/deprecated.css?dep=$DEP_VERSION$" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript>
   <link rel="stylesheet" href="/wdn/templates_5.0/css/core.css?dep=$DEP_VERSION$">
   <link rel="stylesheet" href="https://cloud.typography.com/7717652/6968572/css/fonts.css">
-  <link rel="stylesheet" href="/wdn/templates_5.0/css/deprecated.css?dep=$DEP_VERSION$">
 </noscript>
 <link rel="preload" href="https://ucommchat.unl.edu/assets/css?for=client&v=5" as="style">
 <link rel="stylesheet" href="/wdn/templates_5.0/css/print.css?dep=$DEP_VERSION$" media="print">

--- a/wdn/templates_5.0/includes/global/head-2.html
+++ b/wdn/templates_5.0/includes/global/head-2.html
@@ -3,11 +3,9 @@
 <script>document.documentElement.classList.remove("no-js");</script>
 <link id="unl-css-core" rel="preload" href="https://unlcms.unl.edu/wdn/templates_5.0/css/core.css?dep=$DEP_VERSION$" as="style" onload="this.onload=null;this.rel='stylesheet';">
 <link rel="preload" href="https://cloud.typography.com/7717652/6968572/css/fonts.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
-<link rel="preload" href="https://unlcms.unl.edu/wdn/templates_5.0/css/deprecated.css?dep=$DEP_VERSION$" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript>
   <link rel="stylesheet" href="https://unlcms.unl.edu/wdn/templates_5.0/css/core.css?dep=$DEP_VERSION$">
   <link rel="stylesheet" href="https://cloud.typography.com/7717652/6968572/css/fonts.css">
-  <link rel="stylesheet" href="https://unlcms.unl.edu/wdn/templates_5.0/css/deprecated.css?dep=$DEP_VERSION$">
 </noscript>
 <link rel="preload" href="https://ucommchat.unl.edu/assets/css?for=client&v=5" as="style">
 <link rel="stylesheet" href="https://unlcms.unl.edu/wdn/templates_5.0/css/print.css?dep=$DEP_VERSION$" media="print">


### PR DESCRIPTION
To continue using 4.1 classes outside UNLcms, you'll need to manually include the stylesheet link in your `<head>` section. See: https://wdn.unl.edu/documentation/5.0/using-olddeprecated-classes-and-css