### PR TITLE
Temporarily remove reduced motion preference; update search & mobile nav modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -362,9 +362,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -3136,7 +3136,7 @@
       }
     },
     "dcf": {
-      "version": "git+https://github.com/d-c-n/dcf.git#bd8f89995378656bdc9b3d823f172548be3cd0ee",
+      "version": "git+https://github.com/d-c-n/dcf.git#352ad393de6bee44393d242f936c5ef6d4279049",
       "from": "git+https://github.com/d-c-n/dcf.git",
       "dev": true,
       "requires": {
@@ -3934,9 +3934,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -6503,11 +6503,11 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+      "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
@@ -6520,9 +6520,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/wdn/templates_5.0/includes/global/nav-menu-1.html
+++ b/wdn/templates_5.0/includes/global/nav-menu-1.html
@@ -1,1 +1,1 @@
-<nav class="dcf-nav-menu unl-font-sans unl-nav-menu-closed dcf-d-none@print" id="dcf-navigation" role="navigation" aria-label="Primary">
+<nav class="dcf-nav-menu dcf-modal-parent unl-font-sans dcf-d-none@print" id="dcf-navigation" role="navigation" aria-label="Primary">

--- a/wdn/templates_5.0/includes/global/search.html
+++ b/wdn/templates_5.0/includes/global/search.html
@@ -1,4 +1,4 @@
-<div class="dcf-search dcf-header-global-item dcf-flex-grow-1 dcf-d-flex dcf-jc-flex-end dcf-d-none@print" id="dcf-search" role="search">
+<div class="dcf-search dcf-header-global-item dcf-flex-grow-1 dcf-d-flex dcf-jc-flex-end dcf-modal-parent dcf-d-none@print" id="dcf-search" role="search">
   <div class="dcf-search-toggle-wrapper dcf-ai-center dcf-w-100%">
     <a href="https://search.unl.edu/" class="dcf-nav-toggle-btn dcf-nav-toggle-btn-search dcf-search-toggle dcf-d-flex dcf-ai-center dcf-jc-between dcf-w-100% dcf-p-0 dcf-txt-2xs dcf-bg-transparent dcf-b-1 dcf-b-solid unl-b-scarlet unl-font-sans unl-scarlet" id="dcf-search-toggle-link">
       <span class="dcf-search-toggle-label dcf-flex-grow-1 dcf-txt-left">Search</span>
@@ -9,7 +9,7 @@
       </span>
     </a>
   </div>
-  <div class="unl-search-modal dcf-fixed dcf-pin-top dcf-pin-left dcf-h-100% dcf-w-100% dcf-bg-overlay-light" id="dcf-search-results" aria-labelledby="unl-search-modal-heading" aria-hidden="true" role="dialog" tabindex="-1" hidden>
+  <div class="dcf-modal-overlay dcf-mobile-toolbar-modal dcf-bg-overlay-light dcf-p-0" id="dcf-search-results" aria-labelledby="unl-search-modal-heading" aria-hidden="true" role="dialog" tabindex="-1">
     <div class="dcf-d-flex dcf-flex-col dcf-flex-nowrap dcf-h-100% dcf-w-100%" role="document">
       <h2 class="dcf-sr-only" id="unl-search-modal-heading">Search Form</h2>
       <div class="dcf-bleed dcf-bg-center dcf-bg-no-repeat dcf-bg-cover unl-bg-scarlet unl-search-bg">

--- a/wdn/templates_5.0/js-src/navigation.babel.js
+++ b/wdn/templates_5.0/js-src/navigation.babel.js
@@ -82,13 +82,6 @@ define(['plugins/headroom', 'plugins/body-scroll-lock'], function(Headroom, body
         }
       }
 
-      function modalTransition(event) {
-        modalParent.removeEventListener('transitionend', modalTransition);
-        if (!modalParent.classList.contains('unl-nav-menu-closed')) {
-          modalParent.classList.add('unl-nav-menu-closed');
-        }
-      }
-
       function openNavModal() {
         if (window.matchMedia("(max-width: 56.12em)").matches) {
           skipNav.setAttribute('aria-hidden', 'true');
@@ -105,8 +98,7 @@ define(['plugins/headroom', 'plugins/body-scroll-lock'], function(Headroom, body
           toggleButtons[i].setAttribute('aria-expanded', 'true');
           toggleButtons[i].setAttribute('aria-label', 'close menu');
         }
-        modalParent.classList.remove('unl-nav-menu-closed');
-        modalParent.classList.add('unl-nav-menu-open');
+        modalParent.classList.add('dcf-modal-open');
         toggleIconOpen.classList.add('dcf-d-none');
         toggleIconClose.classList.remove('dcf-d-none');
         toggleLabel.textContent = 'Close';
@@ -134,8 +126,7 @@ define(['plugins/headroom', 'plugins/body-scroll-lock'], function(Headroom, body
           toggleButtons[i].setAttribute('aria-expanded', 'false');
           toggleButtons[i].setAttribute('aria-label', 'open menu');
         }
-        modalParent.addEventListener('transitionend', modalTransition);
-        modalParent.classList.remove('unl-nav-menu-open');
+        modalParent.classList.remove('dcf-modal-open');
         toggleIconOpen.classList.remove('dcf-d-none');
         toggleIconClose.classList.add('dcf-d-none');
         toggleLabel.textContent = 'Menu';
@@ -148,14 +139,14 @@ define(['plugins/headroom', 'plugins/body-scroll-lock'], function(Headroom, body
 
       // add an event listener for closeSearchEvent
       document.addEventListener('closeNavigation', function(e) {
-        if (modalParent.classList.contains('unl-nav-menu-open')) {
+        if (modalParent.classList.contains('dcf-modal-open')) {
           closeNavModal();
         }
       });
 
       // add an event listener for resize
       window.addEventListener('resize', function(e) {
-        if (window.matchMedia("(max-width: 56.12em)").matches && modalParent.classList.contains('unl-nav-menu-open')) {
+        if (window.matchMedia("(max-width: 56.12em)").matches && modalParent.classList.contains('dcf-modal-open')) {
           main.setAttribute('inert', '');
           footer.setAttribute('inert', '');
           disableBodyScroll(mobileNavMenu);
@@ -168,7 +159,7 @@ define(['plugins/headroom', 'plugins/body-scroll-lock'], function(Headroom, body
 
       let toggleButtonOnClick = function() {
           activeToggleButton = this;
-          if (modalParent.classList.contains('unl-nav-menu-open')) {
+          if (modalParent.classList.contains('dcf-modal-open')) {
             closeNavModal();
           } else {
             openNavModal();

--- a/wdn/templates_5.0/js-src/search.babel.js
+++ b/wdn/templates_5.0/js-src/search.babel.js
@@ -103,24 +103,9 @@ define(['wdn', 'require', 'plugins/body-scroll-lock'], function(WDN, require, bo
         return;
       }
 
-      // Check if search modal has `hidden` attribute
-      if (domDialog.hasAttribute('hidden')) {
-        // Remove `hidden` attribute
-        domDialog.removeAttribute('hidden');
-        // Replace with these classes
-        domDialog.classList.add('dcf-opacity-0', 'dcf-pointer-events-none', 'dcf-invisible');
-      }
-
-      function modalTransition(event) {
-        domDialog.removeEventListener('transitionend', modalTransition);
-        if (!domDialog.classList.contains('dcf-invisible')) {
-          domDialog.classList.add('dcf-invisible');
-        }
-      }
-
       var domToggleButtonOnClick = function(e) {
 
-        if (domDialog.classList.contains('dcf-invisible')) {
+        if (!domDialog.classList.contains('dcf-modal-open')) {
 
           // Search is currently closed, so open it.
           for (let i = 0; i < domToggleButtons.length; i++) {
@@ -137,8 +122,7 @@ define(['wdn', 'require', 'plugins/body-scroll-lock'], function(WDN, require, bo
           nav.setAttribute('aria-hidden', 'true');
           main.setAttribute('aria-hidden', 'true');
           footer.setAttribute('aria-hidden', 'true');
-          domDialog.classList.remove('dcf-opacity-0', 'dcf-pointer-events-none', 'dcf-invisible');
-          domDialog.classList.add('dcf-opacity-100', 'dcf-pointer-events-auto');
+          domDialog.classList.add('dcf-modal-open');
           domDialog.setAttribute('aria-hidden', 'false');
           domActiveToggleButton = this;
 
@@ -260,7 +244,7 @@ define(['wdn', 'require', 'plugins/body-scroll-lock'], function(WDN, require, bo
       };
 
       let closeSearch = function(returnFocus = false) {
-        if (domDialog.classList.contains('dcf-invisible')) {
+        if (!domDialog.classList.contains('dcf-modal-open')) {
           // Search is already closed.
           return;
         }
@@ -275,9 +259,7 @@ define(['wdn', 'require', 'plugins/body-scroll-lock'], function(WDN, require, bo
         nav.setAttribute('aria-hidden', 'false');
         main.setAttribute('aria-hidden', 'false');
         footer.setAttribute('aria-hidden', 'false');
-        domDialog.addEventListener('transitionend', modalTransition);
-        domDialog.classList.remove('dcf-opacity-100', 'dcf-pointer-events-auto');
-        domDialog.classList.add('dcf-opacity-0', 'dcf-pointer-events-none');
+        domDialog.classList.remove('dcf-modal-open');
         domDialog.setAttribute('aria-hidden', 'true');
         for (let i = 0; i < domToggleButtons.length; i++) {
           domToggleButtons[i].setAttribute('aria-expanded', 'false');

--- a/wdn/templates_5.0/scss/components/_components.dev.scss
+++ b/wdn/templates_5.0/scss/components/_components.dev.scss
@@ -3,6 +3,37 @@
 ////////////////////////////
 
 
+// Temp modal
+.dcf-modal-overlay {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  transition: none;
+  width: 100%;
+  z-index: 100149;
+}
+
+// Modal is closed, hidden
+.dcf-modal-overlay[aria-hidden=true] {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity $timing-fade-out $easing-fade-out, visibility 0ms .4s;
+	visibility: hidden;
+}
+
+// Modal is open, visible
+.dcf-modal-overlay[aria-hidden=false] {
+	opacity: 1;
+	pointer-events: auto;
+	transition: opacity $timing-fade-in $easing-fade-in;
+	visibility: visible;
+}
+
+
 .unl-stripes::after {
   background-image: repeating-linear-gradient($diagonal1, fade-out($color-body,.5), fade-out($color-body,.5) 1px, transparent 1px, transparent 2px);
   content: '';

--- a/wdn/templates_5.0/scss/components/_components.nav-menu.scss
+++ b/wdn/templates_5.0/scss/components/_components.nav-menu.scss
@@ -34,11 +34,6 @@
 
 @include mq(md, max, width) {
 
-  .unl-nav-menu-closed {
-    visibility: hidden;
-  }
-
-
   .unl .dcf-nav-menu {
     @include bg-overlay-light;
     bottom: #{$height-mobile-toolbar};
@@ -46,17 +41,19 @@
     opacity: 0;
     pointer-events: none;
     position: fixed;
-    transition: opacity 300ms ease-out;
+    transition: opacity $timing-fade-out $easing-fade-out, visibility 0ms .4s;
+    visibility: hidden;
     width: 100%;
     z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
 
 
   // Open when parent model is open
-  .unl .dcf-nav-menu.unl-nav-menu-open {
-    opacity: 1;
-    pointer-events: auto;
-    transition: opacity 200ms ease-out;
+  .unl .dcf-nav-menu.dcf-modal-open {
+  	opacity: 1;
+  	pointer-events: auto;
+  	transition: opacity $timing-fade-in $easing-fade-in;
+  	visibility: visible;
   }
 
 

--- a/wdn/templates_5.0/scss/components/_components.search.scss
+++ b/wdn/templates_5.0/scss/components/_components.search.scss
@@ -3,19 +3,8 @@
 ///////////////////////////////
 
 
-.unl-search-modal {
+#dcf-search-results {
   z-index: 999; // Must be below the modal z-index, but above the nav local z-index
-}
-
-// Modal is closed, hidden
-.unl-search-modal[aria-hidden="true"] {
-  transition: opacity $timing-fade-out $easing-fade-out;
-}
-
-
-// Modal is open, visible
-.unl-search-modal[aria-hidden="false"] {
-  transition: opacity $timing-fade-in $easing-fade-in;
 }
 
 

--- a/wdn/templates_5.0/scss/critical.scss
+++ b/wdn/templates_5.0/scss/critical.scss
@@ -1905,7 +1905,9 @@ a.unl-cream:link {
   .unl .dcf-nav-toggle-btn {
     flex-basis: 25%;
   }
-  .unl-nav-menu-closed {
+  .unl .dcf-nav-menu {
+    opacity: 0;
+    pointer-events: none;
     visibility: hidden;
   }
   .unl .dcf-header .dcf-institution-title,
@@ -2019,4 +2021,9 @@ a.unl-cream:link {
   .unl .dcf-txt-h1 {
     font-size: 2.37em!important;
   }
+}
+.dcf-modal-overlay[aria-hidden=true] {
+	opacity: 0;
+	pointer-events: none;
+	visibility: hidden;
 }

--- a/wdn/templates_5.0/scss/critical.tmp.scss
+++ b/wdn/templates_5.0/scss/critical.tmp.scss
@@ -1955,7 +1955,9 @@ a.unl-cream:link {
   .unl .dcf-nav-toggle-btn {
     flex-basis: 25%;
   }
-  .unl-nav-menu-closed {
+  .unl .dcf-nav-menu {
+    opacity: 0;
+    pointer-events: none;
     visibility: hidden;
   }
   .unl .dcf-header .dcf-institution-title,
@@ -2069,4 +2071,9 @@ a.unl-cream:link {
   .unl .dcf-txt-h1 {
     font-size: 2.37em!important;
   }
+}
+.dcf-modal-overlay[aria-hidden=true] {
+	opacity: 0;
+	pointer-events: none;
+	visibility: hidden;
 }


### PR DESCRIPTION
Temporarily remove `prefers-reduced-motion` media query and revert to previously-used method for transitioning modal states for search and mobile navigation. This media query will be restored as soon as possible.