### PR TITLE
Remove jquery polyfill hack

### DIFF
--- a/wdn/templates_5.0/js-src/jquery.js
+++ b/wdn/templates_5.0/js-src/jquery.js
@@ -10145,8 +10145,7 @@
     return this;
   };
 
-  // Polyfill hack
-  jQuery.fn.load = function(callback){ jQuery(window).on("load", callback) };
+
 
 
 // Attach a bunch of functions for handling common AJAX events


### PR DESCRIPTION
The polyfill hack was causing issues with jquery colorbox.  

I was not able to replicate the issue that resulted in adding the hack, which was an unlikely edge case, so not adding an alternative fix at this time.  We can address if an issue occurs in the future.

This update addresses this issue: https://github.com/unl/wdntemplates/issues/1361
