### PR TITLE
Add mixin/utility to match heading letter-spacing

### DIFF
--- a/wdn/templates_5.0/scss/components/_components.headings.scss
+++ b/wdn/templates_5.0/scss/components/_components.headings.scss
@@ -3,28 +3,6 @@
 /////////////////////////////////
 
 
-.unl h1,
-.unl h2,
-.unl h3,
-.unl h4,
-.unl h5,
-.unl h6 {
-  @include font-sans;
-  font-weight: 700;
-  @include ls-h;
-}
-
-
-.unl h1 a,
-.unl h2 a,
-.unl h3 a,
-.unl h4 a,
-.unl h5 a,
-.unl h6 a {
-  text-decoration: none;
-}
-
-
 .unl .dcf-subhead {
   font-weight: 400;
   font-size: #{ms(-2)}rem;

--- a/wdn/templates_5.0/scss/components/_components.headings.scss
+++ b/wdn/templates_5.0/scss/components/_components.headings.scss
@@ -11,8 +11,7 @@
 .unl h6 {
   @include font-sans;
   font-weight: 700;
-  letter-spacing: -.03em;
-  margin-left: -.03em;
+  @include ls-h;
 }
 
 

--- a/wdn/templates_5.0/scss/core.tmp.scss
+++ b/wdn/templates_5.0/scss/core.tmp.scss
@@ -99,6 +99,7 @@
 @import "../../../node_modules/dcf/assets/dist/scss/elements/_elements.sup-sub";
 @import "../../../node_modules/dcf/assets/dist/scss/elements/_elements.tables";
 @import "elements/_elements.details-summary";
+@import "elements/_elements.headings";
 @import "elements/_elements.tables";
 
 

--- a/wdn/templates_5.0/scss/elements/_elements.headings.scss
+++ b/wdn/templates_5.0/scss/elements/_elements.headings.scss
@@ -1,0 +1,24 @@
+///////////////////////////////
+// !THEME / ELEMENTS / HEADINGS
+///////////////////////////////
+
+
+.unl h1,
+.unl h2,
+.unl h3,
+.unl h4,
+.unl h5,
+.unl h6 {
+  @include font-sans;
+  font-weight: 700;
+  @include ls-h;
+}
+
+.unl h1 a,
+.unl h2 a,
+.unl h3 a,
+.unl h4 a,
+.unl h5 a,
+.unl h6 a {
+  text-decoration: none;
+}

--- a/wdn/templates_5.0/scss/mixins/_mixins.typography.scss
+++ b/wdn/templates_5.0/scss/mixins/_mixins.typography.scss
@@ -127,6 +127,10 @@
 @mixin ls-1($imp:null) { letter-spacing: #{ms(-30)}em $imp; }
 @mixin ls-2($imp:null) { letter-spacing: #{ms(-20)}em $imp; }
 @mixin ls-3($imp:null) { letter-spacing: #{ms(-16)}em $imp; }
+@mixin ls-h($imp:null) {
+  letter-spacing: -#{ms(-24)}em $imp;
+  margin-left: -#{ms(-24)}em $imp;
+}
 
 
 // !Line-Height Crop

--- a/wdn/templates_5.0/scss/utilities/_utilities.typography.scss
+++ b/wdn/templates_5.0/scss/utilities/_utilities.typography.scss
@@ -30,6 +30,7 @@
 .unl-ls-1 { @include ls-1(!important); }
 .unl-ls-2 { @include ls-2(!important); }
 .unl-ls-3 { @include ls-3(!important); }
+.unl-ls-h { @include ls-h(!important); }
 
 
 // !Line-Height Crop


### PR DESCRIPTION
- Add mixin/utility to match the tighter `letter-spacing` and negative `margin-left` of headings
- Use mixin for heading `letter-spacing` and `margin-left`
- Move heading styles to new elements partial