### PR TITLE
Fix legacy hero breadcrumbs display and image/video opacity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdntemplates",
-  "version": "5.0.14",
+  "version": "5.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/wdn/templates_5.0/scss/components/_components.heroes-legacy.scss
+++ b/wdn/templates_5.0/scss/components/_components.heroes-legacy.scss
@@ -4,7 +4,7 @@
 
 
 // Legacy hero
-.unl-hero-legacy .dcf-breadcrumbs {
+.unl-hero-legacy .dcf-breadcrumbs-wrapper {
   display: none;
 }
 

--- a/wdn/templates_5.0/scss/components/_components.heroes-legacy.scss
+++ b/wdn/templates_5.0/scss/components/_components.heroes-legacy.scss
@@ -44,11 +44,15 @@
     height: #{ms(28)}vh;
     left: 0;
     max-height: #{ms(24)}em;
-    opacity: .5;
     overflow: hidden;
     position: absolute;
     top: 0;
     width: 100%;
+  }
+
+  .unl-hero-legacy .dcf-hero-group-2 img,
+  .unl-hero-legacy .dcf-hero-group-2 video {
+    opacity: .5;
   }
 
 }


### PR DESCRIPTION
- Hide the breadcrumbs wrapper instead of only the breadcrumbs.
- Apply reduced opacity to images and videos, not the whole hero group. If a photo credit is included, it too will have decreased opacity and fail color contrast compliance.