### PR TITLE
Revert warning color value

### DIFF
--- a/wdn/templates_5.1/scss/variables/_variables.colors.scss
+++ b/wdn/templates_5.1/scss/variables/_variables.colors.scss
@@ -59,7 +59,7 @@ $darkest-gray: darken($mix-cream-gray, 75%);    // #242423
 // CONTEXTUAL COLORS
 $color-info: $blue;
 $color-success: $green;
-$color-warning: $yellow;
+$color-warning: #e72c0c; // TODO: replace with $yellow when notices are redesigned
 $color-danger: #b60000; // TODO: update for notices
 
 $color-highlight: #ff0;


### PR DESCRIPTION
Revert the "warning" color variable to orange until the notices are redesigned. The yellow isn't compatible with the current (old 4.x) design of the notices.
