### PR TITLE
Support location webpage url link

### DIFF
--- a/wdn/templates_5.1/js-src/events-band.js
+++ b/wdn/templates_5.1/js-src/events-band.js
@@ -68,23 +68,31 @@ define([
           time = '';
           ampm = '';
         }
+
         var location = '';
 
-        if (event.Locations[0] && event.Locations[0].Address.BuildingName) {
-          location = event.Locations[0].Address.BuildingName;
-        }
-
-        if (localConfig.rooms) {
-          if (event.Room) {
-            var room = event.Room;
-            if (room.match(/^room /i)) {
-              room = room.substring(5);
-            }
-            if (location != '') {
-              location = location + '<br>';
-            }
-            location = location + 'Room: ' + room;
+        if (event.Locations[0] !== undefined && event.Locations[0].Address.BuildingName) {
+          if (event.Locations[0].MapLinks[0]) {
+            location += '<a class="dcf-txt-decor-hover unl-dark-gray" href="'+ event.Locations[0].MapLinks[0] +'">';
+          } else if (event.Locations[0].WebPages[0].URL) {
+            location += '<a class="dcf-txt-decor-hover unl-dark-gray" href="'+ event.Locations[0].WebPages[0].URL +'">';
           }
+          location += event.Locations[0].Address.BuildingName
+          if (event.Locations[0].MapLinks[0] || event.Locations[0].WebPages[0].URL) {
+            location += '</a>';
+          }
+
+          if (localConfig.rooms) {
+            if (event.Room) {
+              var room = event.Room;
+              if (room.match(/^room /i)) {
+                room = room.substring(5);
+              }
+              location = location + '<br>Room: ' + room;
+            }
+          }
+
+          location += '</span>';
         }
 
         var eventURL = '';

--- a/wdn/templates_5.1/js-src/events.js
+++ b/wdn/templates_5.1/js-src/events.js
@@ -70,21 +70,23 @@ define([
         location =  '<div class="unl-event-location dcf-txt-xs dcf-pt-1 unl-font-sans unl-dark-gray">';
         if (event.Locations[0].MapLinks[0]) {
           location += '<a class="dcf-txt-decor-hover unl-dark-gray" href="'+ event.Locations[0].MapLinks[0] +'">';
+        } else if (event.Locations[0].WebPages[0].URL) {
+          location += '<a class="dcf-txt-decor-hover unl-dark-gray" href="'+ event.Locations[0].WebPages[0].URL +'">';
         }
         location += event.Locations[0].Address.BuildingName
-        if (event.Locations[0].MapLinks[0]) {
+        if (event.Locations[0].MapLinks[0] || event.Locations[0].WebPages[0].URL) {
           location += '</a>';
         }
 
         if (config.rooms) {
           if (event.Room) {
-                      var room = event.Room;
-                      if (room.match(/^room /i)) {
-                          room = room.substring(5);
-                      }
-                      location = location + '<br>Room: ' + room;
-                  }
-              }
+            var room = event.Room;
+            if (room.match(/^room /i)) {
+              room = room.substring(5);
+            }
+            location = location + '<br>Room: ' + room;
+          }
+        }
 
         location += '</span>';
       }


### PR DESCRIPTION
To better support virtual locations (zoom meeting), I updated the event's website to link locations with the web page URL defined to the URL.  This change makes the same change for our WDN events plugins. It also syncs the behavior between the events and events-band plugin for location display behavior.
