### PR TITLE
Fix calls to action (Visit/Apply/Give) display for app templates

### DIFF
--- a/wdn/templates_5.2/scss/components/_components.app.scss
+++ b/wdn/templates_5.2/scss/components/_components.app.scss
@@ -16,7 +16,7 @@
 
 @include mq(md, max, width) {
 
-  .unl.app .dcf-app-controls ul {
+  .unl.app .dcf-app-controls ul:not(:last-child) {
     flex-direction: column;
   }
 
@@ -30,7 +30,7 @@
     justify-content: space-between;
   }
 
-  .unl.app .dcf-app-controls ul {
+  .unl.app .dcf-app-controls ul:not(:last-child) {
     border-left: 1px solid $scarlet-shade;
     display: flex;
   }

--- a/wdn/templates_5.2/scss/components/_components.nav-local.scss
+++ b/wdn/templates_5.2/scss/components/_components.nav-local.scss
@@ -37,16 +37,6 @@
     grid-gap: $length-em-6 $length-vw-1;
   }
 
-
-  .unl .dcf-nav-local a {
-    margin-left: -#{ms(0)}rem;
-  }
-
-
-  .unl .dcf-nav-local ul ul {
-    @include txt-xs;
-  }
-
 }
 
 
@@ -90,7 +80,6 @@
 
 
   .unl .dcf-nav-local ul ul {
-    @include txt-sm;
     @include pb-7;
     width: 100%;
   }

--- a/wdn/templates_5.2/scss/components/_components.nav-menu.scss
+++ b/wdn/templates_5.2/scss/components/_components.nav-menu.scss
@@ -101,6 +101,17 @@
     bottom: $height-mobile-toolbar;
   }
 
+
+  .unl .dcf-nav-menu a,
+  .unl .dcf-nav-menu button {
+    margin-left: -#{ms(0)}rem;
+  }
+
+
+  .unl .dcf-nav-menu ul ul {
+    @include txt-xs;
+  }
+
 }
 
 
@@ -114,8 +125,14 @@
     padding-right: $length-vw-2;
   }
 
+
+  .unl .dcf-nav-menu ul ul {
+    @include txt-sm;
+  }
+
+
   .unl .dcf-nav-menu a,
-  .unl .dcf-nav-menu button, {
+  .unl .dcf-nav-menu button {
     @include txt-xs;
   }
 


### PR DESCRIPTION
- Hide/show calls to action in correct places for “mobile” and “desktop”
- Adjust button and link font-size, margin for app menu