### PR TITLE
Add check for desktopBtn for app templates

### DIFF
--- a/wdn/templates_5.2/js-src/navigation.babel.js
+++ b/wdn/templates_5.2/js-src/navigation.babel.js
@@ -169,9 +169,9 @@ define(['plugins/headroom', 'plugins/body-scroll-lock'], function(Headroom, body
       const hasChild = allPrimaryNavLi.find((el)=>el.querySelector('ul'));
       const desktopBtn = document.getElementById('dcf-menu-toggle');
       // Show "desktop" menu toggle button if navigation contains children
-      hasChild && desktopBtn.removeAttribute('hidden');
-      hasChild && desktopBtn.setAttribute('aria-expanded', 'false');
-      hasChild && desktopBtn.setAttribute('aria-label', 'open menu');
+      hasChild && desktopBtn && desktopBtn.removeAttribute('hidden');
+      hasChild && desktopBtn && desktopBtn.setAttribute('aria-expanded', 'false');
+      hasChild && desktopBtn && desktopBtn.setAttribute('aria-label', 'open menu');
     }
   };
 


### PR DESCRIPTION
App templates do not have `dcf-menu-toogle` so need to add check to prevent javascript error.