### PR TITLE
Use relative paths for node-sass includePaths in Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -298,7 +298,7 @@ module.exports = function (grunt) {
           sourceMap: true,
           precision: 2,
           includePaths: [
-            __dirname+'/node_modules/modularscale-sass/stylesheets'
+            'node_modules/modularscale-sass/stylesheets'
           ]
         },
         files: scssAllFiles
@@ -309,7 +309,7 @@ module.exports = function (grunt) {
           sourceMap: true,
           precision: 2,
           includePaths: [
-            __dirname+'/node_modules/modularscale-sass/stylesheets'
+            'node_modules/modularscale-sass/stylesheets'
           ]
         },
         files: scssJsFiles


### PR DESCRIPTION
This PR seeks to change the paths used by node-sass includePaths in Gruntfile.js from absolute paths to relative paths. In the event the absolute path contains certain characters (including colons), Grunt will complain it is unable to find the files to be included by the includePaths value.

For example, if the absolute path contains a colon:

`/var/www/html/dxg-dev.unl.edu:8440/vendor/unl/wdntemplates/node_modules/modularscale-sass/stylesheets`

```
Running "sass:main" (sass) task
Fatal error: Error: File to import not found or unreadable: modularscale.
        on line 7 of wdn/templates_5.1/scss/variables/_variables.modular-scale.scss
        from line 6 of wdn/templates_5.1/scss/variables/_variables.abbreviations.scss
        from line 12 of wdn/templates_5.1/scss/critical.tmp.scss
>> @import 'modularscale';
```

Note: This PR is targeted to '5.2' branch. I'd also like to have this cherry picked to '5.1'.