### PR TITLE
Default mediaelement duration to 0 if not a number

### DIFF
--- a/wdn/templates_5.2/js-src/plugins/mediaelement/mediaelement-and-player.js
+++ b/wdn/templates_5.2/js-src/plugins/mediaelement/mediaelement-and-player.js
@@ -4273,7 +4273,7 @@ if (typeof jQuery != 'undefined') {
 					var seconds = media.currentTime,
 						timeSliderText = mejs.i18n.t('mejs.time-slider'),
 						time = mejs.Utility.secondsToTimeCode(seconds, player.options),
-						duration = media.duration;
+						duration = !isNaN(media.duration) ? media.duration: 0;
 
 					t.slider.attr({
 						'aria-label': timeSliderText,


### PR DESCRIPTION
This update will default the `aria-valuemax` which uses the `media.duration` to 0 if evaluates to NAN so to fix issue in web audit.

You can test in debug.shtml with:

```
<div class="dcf-mb-6">
      <audio class="wdn_player" preload="auto" src="https://s3-us-west-2.amazonaws.com/agalmanac/090720/Hendrickson1.mp3"></audio>
      <script>
        window.addEventListener('inlineJSReady', function(){
          WDN.initializePlugin('mediaelement_wdn');
        });
      </script>
</div>
```
and verify that the `aria-valuemax` of the div with class of `mejs-time-rail` has value of `0`. Note this value will change if the audio is played.