### PR TITLE
Fix responsive table mobile display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdntemplates",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3284,7 +3284,7 @@
       "dev": true
     },
     "dcf": {
-      "version": "git://github.com/digitalcampusframework/dcf.git#bac118e06942d03b787f5650cbd0e608d58a4d6d",
+      "version": "git://github.com/digitalcampusframework/dcf.git#e7f28b9c077380661b9b0f80b27f4e259c603407",
       "from": "git://github.com/digitalcampusframework/dcf.git#2.0",
       "dev": true
     },

--- a/wdn/templates_5.2/scss/variables/_variables.tables.scss
+++ b/wdn/templates_5.2/scss/variables/_variables.tables.scss
@@ -65,3 +65,7 @@ $padding-top-table-bordered-thead-cell: $length-em-5;                   // Paddi
 $padding-bottom-table-scroll: $length-em-4;                             // Padding-bottom for scrollable tables (to account for scroll bar)
 
 $padding-bottom-table-responsive-tbody-tr: $padding-bottom-tbody-cell;  // Padding-bottom for responsive table <tbody> rows
+
+
+// Width
+$width-table-responsive-data-label: 40%;                    // Width of data-label (responsive table heading)


### PR DESCRIPTION
Responsive table fix was [merged](https://github.com/digitalcampusframework/dcf/pull/362#issuecomment-738961356) into the DCF `master` branch but not the DCF `2.0` branch.