### PR TITLE
Bug fix to display QA test star

### DIFF
--- a/wdn/templates_5.2/js-src/qa.js
+++ b/wdn/templates_5.2/js-src/qa.js
@@ -8,7 +8,7 @@ define(['jquery'], function($) {
         }
 
         var gpa = parseFloat(data.gpa);
-        var $link = $('a[href="https://webaudit.unl.edu/qa-test/"]');
+        var $link = $('#qa-test');
         if (gpa === 100) {
             $link.after('<span aria-hidden="true">&nbsp;&starf;</span><span class="dcf-sr-only">100% (gold star)</span>');
         } else if (gpa >= 90) {


### PR DESCRIPTION
Update to correctly add star to qa test link with recent change to `main.babel.js` which adds query string to the link.