### PR TITLE
Prevent fade on first carousel slide

### DIFF
--- a/wdn/templates_5.2/js-src/carousel.js
+++ b/wdn/templates_5.2/js-src/carousel.js
@@ -20,7 +20,8 @@ define([
 			$(function() {
 				var userConfig = WDN.getPluginParam('carousel', 'defaults') || {};
 				var defaultConfig = {
-                    directionNav: false
+					directionNav: false,
+					fadeFirstSlide: false
 				};
 
 				var localConfig = $.extend({}, defaultConfig, userConfig);


### PR DESCRIPTION
This fix is to possibly help with aria contrast issues with web audit so the first slide is not faded in on page load.

Can test from `{dev-wdntemplates-site}/wdn/templates_5.2/examples/#carousel.html`