### PR TITLE
Remove object-fit polyfill

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -318,7 +318,6 @@ module.exports = function (grunt) {
           processors: [
             require('postcss-normalize')({allowDuplicates: true}),
             require('autoprefixer')(),
-            require('postcss-object-fit-images'),
             require('cssnano')()
           ],
           map: true
@@ -329,7 +328,6 @@ module.exports = function (grunt) {
         options: {
           processors: [
             require('autoprefixer')(),
-            require('postcss-object-fit-images'),
             require('cssnano')()
           ],
           map: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,45 +2775,6 @@
         }
       }
     },
-    "css-font-size-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss=",
-      "dev": true
-    },
-    "css-font-stretch-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA=",
-      "dev": true
-    },
-    "css-font-style-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ=",
-      "dev": true
-    },
-    "css-font-weight-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc=",
-      "dev": true
-    },
-    "css-global-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
-      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk=",
-      "dev": true
-    },
-    "css-list-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-1.0.1.tgz",
-      "integrity": "sha1-//VxkiAtuDJAxBaG+RnkSacCT30=",
-      "dev": true,
-      "requires": {
-        "tcomb": "^2.5.0"
-      }
-    },
     "css-rule-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/css-rule-stream/-/css-rule-stream-1.1.0.tgz",
@@ -2878,12 +2839,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
-      "dev": true
-    },
-    "css-system-font-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0=",
       "dev": true
     },
     "css-tokenize": {
@@ -9121,23 +9076,6 @@
         }
       }
     },
-    "parse-css-font": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-2.0.2.tgz",
-      "integrity": "sha1-e2CwYHBaJam5C38O1JPlgjJIplI=",
-      "dev": true,
-      "requires": {
-        "css-font-size-keywords": "^1.0.0",
-        "css-font-stretch-keywords": "^1.0.1",
-        "css-font-style-keywords": "^1.0.1",
-        "css-font-weight-keywords": "^1.0.0",
-        "css-global-keywords": "^1.0.1",
-        "css-list-helpers": "^1.0.1",
-        "css-system-font-keywords": "^1.0.0",
-        "tcomb": "^2.5.0",
-        "unquote": "^1.1.0"
-      }
-    },
     "parse-entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
@@ -11340,46 +11278,6 @@
         }
       }
     },
-    "postcss-object-fit-images": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-object-fit-images/-/postcss-object-fit-images-1.1.2.tgz",
-      "integrity": "sha1-i3cwQ9sUZy72zW8ssfDYsmqfVzs=",
-      "dev": true,
-      "requires": {
-        "parse-css-font": "^2.0.2",
-        "postcss": "^5.0.16",
-        "quote": "^0.4.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
-      }
-    },
     "postcss-ordered-values": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
@@ -12160,12 +12058,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true
-    },
-    "quote": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
-      "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=",
       "dev": true
     },
     "raw-body": {
@@ -14726,12 +14618,6 @@
           }
         }
       }
-    },
-    "tcomb": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tcomb/-/tcomb-2.7.0.tgz",
-      "integrity": "sha1-ENYpWAQWaaXVNWe5pO6M3iKxwrA=",
-      "dev": true
     },
     "temp-dir": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "load-grunt-tasks": "^4.0.0",
     "node-sass": "^4.14.1",
     "postcss-normalize": "^7.0.1",
-    "postcss-object-fit-images": "^1.1.2",
     "stylelint": "^13.7.1",
     "stylelint-no-unsupported-browser-features": "^3.0.2",
     "tar-fs": "^1.16.3",


### PR DESCRIPTION
Polyfill was causing font display issues if text was contained within elements that used object-fit. Object-fit is now supported by over 97% of browsers – and we no longer support Internet Explorer.