### PR TITLE
Fix caption color in slideshows

### DIFF
--- a/wdn/templates_5.3/js-src/js-css/slideshows.scss
+++ b/wdn/templates_5.3/js-src/js-css/slideshows.scss
@@ -59,6 +59,7 @@
       0 calc(100% - (#{$size-clip-path} * 2) - (#{$border-width-button} * 2) - #{$size-btn-y}),
       0 0
   );
+  color: $cream;
   height: 100%;
   left: 0;
   padding: $padding-top-slide-caption $padding-right-slide-caption $padding-bottom-slide-caption $padding-left-slide-caption;


### PR DESCRIPTION
Caption contains default `figcaption` color and fails color contrast compliance against the dark slideshow caption background. Thanks @beckyaiken for spotting this!