### PR TITLE
Support featured events in events and events-band widgets

### DIFF
--- a/wdn/templates_5.3/js-src/events-band.js
+++ b/wdn/templates_5.3/js-src/events-band.js
@@ -24,19 +24,32 @@ define([
   defaultCal = 'https://events.unl.edu/';
 
   var fetchEvents = function(localConfig) {
-    var upcoming = 'upcoming/',
+    var type = 'upcoming',
         $container = $(localConfig.container).addClass('dcf-bleed dcf-wrapper dcf-pt-9 dcf-pb-8 unl-bg-lightest-gray unl-bg-grit'),
         grid = document.createElement('div');
         grid.classList.add('unl-offset-grid', 'dcf-col-gap-4');
         eventList = document.createElement('ul');
         eventList.classList.add('unl-event-teaser-list', 'dcf-list-bare', 'dcf-col-gap-vw', 'dcf-row-gap-6', 'dcf-mb-0');
 
-    if (localConfig.url.match(/upcoming\/$/)) {
-      //Don't add the upcoming endpoint if it already exists.
-      upcoming = '';
+    if (localConfig.url.match(/upcoming\/?$/)) {
+      //Don't add the upcoming endpoint if it already exists and set type.
+      localConfig.url = localConfig.url.replace('upcoming/', '');
+      typePath = '';
+      type = 'upcoming';
+    } else if (localConfig.url.match(/featured\/?$/)) {
+      //Don't add the featured endpoint if it already exists and set type.
+      localConfig.url = localConfig.url.replace('featured/', '');
+      typePath = '';
+      type = 'featured';
     }
 
-    var url = localConfig.url + upcoming + '?format=json&limit=' + localConfig.limit;
+    if (localConfig.featured === true) {
+      type = 'featured';
+    }
+
+    typePath = type + '/';
+
+    var url = localConfig.url + typePath + '?format=json&limit=' + localConfig.limit + '&pinned_limit=' + localConfig.pinned_limit;
     $.getJSON(url, function(data) {
       if (!data.Events) {
         return;
@@ -110,10 +123,10 @@ define([
         }
         eventList.innerHTML += '<li class="unl-event-teaser dcf-col-gap-4"><header class="unl-event-title"><h3 class="dcf-mb-0 dcf-lh-3 dcf-bold dcf-txt-h6 unl-lh-crop"><a class="dcf-txt-decor-hover unl-darker-gray" href="' + eventURL + '">' + event.EventTitle + '</a></h3>' + subtitle + '</header><div class="unl-event-datetime dcf-flex-shrink-0 dcf-w-8 dcf-mr-5 dcf-txt-center">' + '<span class="unl-event-month dcf-d-block dcf-txt-3xs dcf-pt-2 dcf-pb-1 dcf-uppercase dcf-bold unl-ls-2 unl-cream unl-bg-scarlet">' + month + '</span><span class="unl-event-day dcf-d-block dcf-txt-h5 dcf-bold dcf-br-1 dcf-bb-1 dcf-bl-1 dcf-br-solid dcf-bb-solid dcf-bl-solid dcf-bg-white unl-br-light-gray unl-bb-light-gray unl-bl-light-gray unl-darker-gray">' + day + '</span><span class="unl-event-time dcf-d-block dcf-pt-2 dcf-txt-2xs dcf-uppercase dcf-bold unl-scarlet">' + time + ' ' + ampm + '</span>' + '</div><div class="unl-event-location dcf-txt-xs dcf-pt-1 unl-dark-gray">' + location + '</div></li>';
       });
-      $container.append('<div class="dcf-absolute dcf-pin-top dcf-pt-9"><h2 class="dcf-m-0 dcf-txt-xs dcf-uppercase dcf-txt-vertical-lr unl-ls-2 unl-dark-gray">Upcoming Events</h2></div>');
+      $container.append('<div class="dcf-absolute dcf-pin-top dcf-pt-9"><h2 class="dcf-m-0 dcf-txt-xs dcf-uppercase dcf-txt-vertical-lr unl-ls-2 unl-dark-gray">' + type + ' Events</h2></div>');
       grid.append(eventList);
       $container.append(grid);
-      $container.append('<div class="dcf-d-flex dcf-jc-flex-end dcf-mt-6"><a class="dcf-btn dcf-btn-secondary" href="' + localConfig.url + '">More Events</a></div>');
+      $container.append('<div class="dcf-d-flex dcf-jc-flex-end dcf-mt-6"><a class="dcf-btn dcf-btn-secondary" href="' + localConfig.url + typePath + '">More Events</a></div>');
     });
   };
 
@@ -124,9 +137,15 @@ define([
       url: localSettings.href || defaultCal,
       container: container,
       limit: localSettings.limit || 10,
+      pinned_limit: localSettings.pinned_limit || 1,
       rooms: false
     },
     localConfig = $.extend({}, defaultConfig, config);
+
+    // Add trailing slash to URL if missing
+    if (localConfig.url && !localConfig.url.match(/\/$/)) {
+      localConfig.url += '/';
+    }
 
     // ensure that the URL we are about to use is forced into an https:// protocol. (add https if it starts with //)
     if (localConfig.url && localConfig.url.match(/^\/\//)) {

--- a/wdn/templates_5.3/js-src/events-band.js
+++ b/wdn/templates_5.3/js-src/events-band.js
@@ -31,13 +31,12 @@ define([
         eventList = document.createElement('ul');
         eventList.classList.add('unl-event-teaser-list', 'dcf-list-bare', 'dcf-col-gap-vw', 'dcf-row-gap-6', 'dcf-mb-0');
 
+    // Handle direct url to upcoming or featured
     if (localConfig.url.match(/upcoming\/?$/)) {
-      //Don't add the upcoming endpoint if it already exists and set type.
       localConfig.url = localConfig.url.replace('upcoming/', '');
       typePath = '';
       type = 'upcoming';
     } else if (localConfig.url.match(/featured\/?$/)) {
-      //Don't add the featured endpoint if it already exists and set type.
       localConfig.url = localConfig.url.replace('featured/', '');
       typePath = '';
       type = 'featured';

--- a/wdn/templates_5.3/js-src/events.js
+++ b/wdn/templates_5.3/js-src/events.js
@@ -131,13 +131,12 @@ define([
       localConfig.url = localConfig.url.replace('http://', 'https://');
     }
 
+    // Handle direct url to upcoming or featured
     if (localConfig.url.match(/upcoming\/?$/)) {
-      //Don't add the upcoming endpoint if it already exists and set type.
       localConfig.url = localConfig.url.replace('upcoming/', '');
       typePath = '';
       type = 'upcoming';
     } else if (localConfig.url.match(/featured\/?$/)) {
-      //Don't add the featured endpoint if it already exists and set type.
       localConfig.url = localConfig.url.replace('featured/', '');
       typePath = '';
       type = 'featured';

--- a/wdn/templates_5.3/js-src/events.js
+++ b/wdn/templates_5.3/js-src/events.js
@@ -18,13 +18,15 @@ define([
     return eventParams || {};
   },
   container = '#wdn_calendarDisplay',
-  defaultCal = 'https://events.unl.edu/';
+  defaultCal = 'https://events.unl.edu/',
+  type = 'upcoming',
+  typePath = type + '/';
 
   var display = function(data, config) {
     var $container = $(config.container).addClass('wdn-calendar');
     $container.hide();
 
-    $container.append($('<h2/>', {'class': 'dcf-d-flex dcf-ai-center dcf-mb-6 dcf-txt-xs dcf-uppercase unl-ls-2 unl-dark-gray unl-txt-stripes-after'}).html('Upcoming Events'));
+    $container.append($('<h2/>', {'class': 'dcf-d-flex dcf-ai-center dcf-mb-6 dcf-txt-xs dcf-uppercase unl-ls-2 unl-dark-gray unl-txt-stripes-after'}).html(type + ' Events'));
 
     var events_html = '';
     $.each(data.Events.Event || data.Events, function(index, event) {
@@ -95,9 +97,9 @@ define([
       events_html += ('<li class="unl-event-teaser">' + title + date + location  + '</li>');
     });
     $container.append('<ul class="dcf-list-bare">' + events_html + '</ul>');
-    var seeAll = '<div class="dcf-mt-4"><a class="dcf-btn dcf-btn-secondary" href="' + config.url + 'upcoming/">See all '+config.title+' events</a></div>';
-    var ics = '<a class="dcf-btn dcf-btn-secondary" href="' + config.url + 'upcoming/?format=ics">ICS</a>';
-    var rss = '<a class="dcf-btn dcf-btn-secondary" href="' + config.url + 'upcoming/?format=rss">RSS</a>';
+    var seeAll = '<div class="dcf-mt-4"><a class="dcf-btn dcf-btn-secondary" href="' + config.url + typePath + '">More '+ config.title+' Events</a></div>';
+    var ics = '<a class="dcf-btn dcf-btn-secondary" href="' + config.url + typePath + '?format=ics">ICS</a>';
+    var rss = '<a class="dcf-btn dcf-btn-secondary" href="' + config.url + typePath + '?format=rss">RSS</a>';
     var feeds = '<div class="dcf-btn-group dcf-mt-4 dcf-mr-5">' + ics + rss + '</div>';
     var more = '<div class="dcf-d-flex dcf-flex-row dcf-flex-wrap dcf-jc-between">' + feeds + seeAll + '</div>';
     $container.append(more);
@@ -111,20 +113,45 @@ define([
       url: localSettings.href || defaultCal,
       container: container,
       limit: localSettings.limit || 10,
+      pinned_limit: localSettings.pinned_limit || 1,
+      featured: false,
       rooms: false
     },
     localConfig = $.extend({}, defaultConfig, config);
 
+    // Add trailing slash to URL if missing
+    if (localConfig.url && !localConfig.url.match(/\/$/)) {
+      localConfig.url += '/';
+    }
+
     // ensure that the URL we are about to use is forced into an https:// protocol. (add https if it starts with //)
-        if (localConfig.url && localConfig.url.match(/^\/\//)) {
-            localConfig.url = 'https:' + localConfig.url;
-        } else if (localConfig.url && localConfig.url.match(/^http:\/\//)) {
-            localConfig.url = localConfig.url.replace('http://', 'https://');
-        }
+    if (localConfig.url && localConfig.url.match(/^\/\//)) {
+      localConfig.url = 'https:' + localConfig.url;
+    } else if (localConfig.url && localConfig.url.match(/^http:\/\//)) {
+      localConfig.url = localConfig.url.replace('http://', 'https://');
+    }
+
+    if (localConfig.url.match(/upcoming\/?$/)) {
+      //Don't add the upcoming endpoint if it already exists and set type.
+      localConfig.url = localConfig.url.replace('upcoming/', '');
+      typePath = '';
+      type = 'upcoming';
+    } else if (localConfig.url.match(/featured\/?$/)) {
+      //Don't add the featured endpoint if it already exists and set type.
+      localConfig.url = localConfig.url.replace('featured/', '');
+      typePath = '';
+      type = 'featured';
+    }
+
+    if (localConfig.featured === true) {
+      type = 'featured';
+    }
+    typePath = type + '/';
 
     if (localConfig.url && $(localConfig.container).length) {
+      var url = localConfig.url + typePath + '?format=json&limit=' + localConfig.limit + '&pinned_limit=' + localConfig.pinned_limit;
       $(this.container).addClass('wdn-calendar');
-      $.getJSON(localConfig.url + 'upcoming/?format=json&limit=' + encodeURIComponent(localConfig.limit), function(data) {
+      $.getJSON(url, function(data) {
           display(data, localConfig);
         }
       );


### PR DESCRIPTION
NOTE: WIP, until Events PR is merged https://github.com/unl/UNL_Events/pull/148

Added two new plugin settings:
* featured - if true will pull featured events from set calendar
* pinned_limit:  how many pinned events that may be included in results (defaults to 1). It should be less than `limit` (defaults to 10).

Also includes some cleanup:
* Allow calendar url path without trailing slash.
* Allow direct calendar path to `upcoming` or `featured` with or without trailing slash.

Usage:

```
<script>
  WDN.setPluginParam('events', 'href', 'https://events-dev.unl.edu');
  WDN.setPluginParam('events', 'title', 'UNL');
  WDN.initializePlugin('events', {featured: true, limit:4, pinned_limit:2});
  WDN.initializePlugin('events-band',{featured: true, limit:4, pinned_limit:2, rooms: true});
</script>
```
or 
```
<script>
  WDN.setPluginParam('events', 'href', 'https://events-dev.unl.edu/featured');
  WDN.setPluginParam('events', 'title', 'UNL');
  WDN.initializePlugin('events', {limit:4, pinned_limit:2});
  WDN.initializePlugin('events-band',{limit:4, pinned_limit:2, rooms: true});
</script>
```