### PR TITLE
Fix institution title color in footer

### DIFF
--- a/wdn/templates_5.3/scss/components/_components.header.scss
+++ b/wdn/templates_5.3/scss/components/_components.header.scss
@@ -3,10 +3,10 @@
 //////////////////////////////
 
 
-.unl a.dcf-institution-title:link,
-.unl a.dcf-institution-title:visited,
+.unl .dcf-header a.dcf-institution-title:link,
+.unl .dcf-header a.dcf-institution-title:visited,
 .unl .dcf-header-global button {
-  color: var(--brand-alpha); // Force visited links in the global header and logo to remain scarlet (light) and cream (dark).
+  color: var(--brand-alpha); // Force visited links in the global header and logo to remain scarlet (light mode) and cream (dark mode).
 }
 
 


### PR DESCRIPTION
Restore specificity to header to prevent footer institution title from inheriting header styles.