### PR TITLE
Fix heading color in notices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdntemplates",
-  "version": "5.3.7",
+  "version": "5.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3413,7 +3413,24 @@
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
           }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
         }
       }
     },
@@ -5220,12 +5237,12 @@
           },
           "dependencies": {
             "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "^2.1.1"
               }
             }
           }

--- a/wdn/templates_5.3/scss/components/_components.notices.scss
+++ b/wdn/templates_5.3/scss/components/_components.notices.scss
@@ -10,7 +10,12 @@
 
 
 // Ensure heading and close link (all states) display as cream
-.unl .dcf-notice-heading,
+// .unl .dcf-notice h1, // An <h1> shouldn't be used at this level.
+.unl .dcf-notice h2,
+.unl .dcf-notice h3,
+.unl .dcf-notice h4,
+.unl .dcf-notice h5,
+.unl .dcf-notice h6,
 .unl .dcf-notice-message a:link,
 .unl .dcf-notice-message a:visited,
 .unl .dcf-notice-message a:hover,


### PR DESCRIPTION
Currently, the default heading color is changed to cream (`#fefdfa`) for only the `.dcf-notice-heading`. This pull request applies the color change to all headings inside the notice – including those nested inside `.dcf-notice-message`. 