### PR TITLE
Update Modal video events to handle YouTube embeds

### DIFF
--- a/wdn/templates_5.3/js-src/modals.babel.js
+++ b/wdn/templates_5.3/js-src/modals.babel.js
@@ -44,18 +44,65 @@ require (['dcf-modal', 'plugins/body-scroll-lock'], (modalModule, bodyScrollLock
     const iframes = modal.getElementsByTagName('iframe');
     if (iframes && iframes.length > 0) {
       Array.prototype.forEach.call(iframes,(iframe) => {
-        let allowAttr = iframe.getAttribute('allow');
+        const source = iframe.getAttribute('src');
+        const allowAttr = iframe.getAttribute('allow');
+
         if (allowAttr && allowAttr.includes('autoplay')) {
+          if (!source.includes('mediahub.unl.edu')) {
+            // Remove autoplay from non-mediaHub url if defined onload
+            try {
+              let url = new URL(iframe.getAttribute('src'));
+              if (url.searchParams.has('autoplay')) {
+                url.searchParams.delete('autoplay');
+                iframe.src = url.toString();
+              }
+            } catch (e) {
+              // do nothing
+            }
+          }
+
           document.addEventListener('ModalOpenEvent_' + modal.id, function (e) {
-            iframe.contentWindow.postMessage('mh-play-video', 'https://mediahub.unl.edu');
+            let currentSource = iframe.getAttribute('src');
+            if (currentSource.includes('mediahub.unl.edu')) {
+              iframe.contentWindow.postMessage('mh-play-video', 'https://mediahub.unl.edu');
+            } else {
+              try {
+                let url = new URL(currentSource);
+                url.searchParams.set('autoplay', '1');
+                const newSource = url.toString();
+                if (currentSource != newSource) {
+                  iframe.src = newSource;
+                }
+              } catch (e) {
+                iframe.src = source;
+              }
+            }
           }, false);
 
           document.addEventListener('ModalCloseEvent_' + modal.id, function (e) {
-            iframe.contentWindow.postMessage('mh-reset-video', 'https://mediahub.unl.edu');
+            let currentSource = iframe.getAttribute('src');
+            if (currentSource.includes('mediahub.unl.edu')) {
+              iframe.contentWindow.postMessage('mh-reset-video', 'https://mediahub.unl.edu');
+            } else {
+              try {
+                let url = new URL(currentSource);
+                if (url.searchParams.has('autoplay')) {
+                  url.searchParams.delete('autoplay');
+                  currentSource = url.toString();
+                }
+                iframe.src = currentSource;
+              } catch (e) {
+                iframe.src = source;
+              }
+            }
           }, false);
-        } else {
+        } else {  // without allow autoplay
           document.addEventListener('ModalCloseEvent_' + modal.id, function (e) {
-            iframe.contentWindow.postMessage('mh-pause-video', 'https://mediahub.unl.edu');
+            if (source.includes('mediahub.unl.edu')) {
+              iframe.contentWindow.postMessage('mh-pause-video', 'https://mediahub.unl.edu');
+            } else {
+              iframe.src = source;
+            }
           }, false);
         }
       });


### PR DESCRIPTION
This update will allow youTube video embeds in WDN DCF Modals to autoplay and stop on modal open and close.
For the video to autoplay, embed iframe must have `allows` attribute with `autoplay` as one of the values.