### PR TITLE
Implement DCF background video toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2540,24 +2540,7 @@
           "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.1"
-              }
-            }
           }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
         }
       }
     },
@@ -3173,8 +3156,8 @@
       "dev": true
     },
     "dcf": {
-      "version": "git://github.com/jsturek/dcf.git#95ecac83ccc35833d53cc4d9e5115cbf206025e2",
-      "from": "git://github.com/jsturek/dcf.git#bg-video-toggle",
+      "version": "git://github.com/digitalcampusframework/dcf.git#0224a54c056df1e4cb6ad5ca4d6789ff66f25005",
+      "from": "git://github.com/digitalcampusframework/dcf.git#3.0",
       "dev": true
     },
     "debug": {
@@ -4358,12 +4341,12 @@
           },
           "dependencies": {
             "is-glob": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -14289,6 +14272,17 @@
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.3"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "4.0.3",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+                  "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "^2.1.1"
+                  }
+                }
               }
             }
           }
@@ -14321,10 +14315,7 @@
         "glob-parent": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-          "requires": {
-            "is-glob": "^4.0.3"
-          }
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="
         },
         "global-modules": {
           "version": "2.0.0",
@@ -14375,21 +14366,14 @@
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
         },
         "kind-of": {
           "version": "6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdntemplates",
-  "version": "5.3.11",
+  "version": "5.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2540,7 +2540,24 @@
           "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
           }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
         }
       }
     },
@@ -3156,8 +3173,8 @@
       "dev": true
     },
     "dcf": {
-      "version": "git://github.com/digitalcampusframework/dcf.git#ee759707214f9cc017b3915e3f5a4a1652d91183",
-      "from": "git://github.com/digitalcampusframework/dcf.git#3.0",
+      "version": "git://github.com/jsturek/dcf.git#95ecac83ccc35833d53cc4d9e5115cbf206025e2",
+      "from": "git://github.com/jsturek/dcf.git#bg-video-toggle",
       "dev": true
     },
     "debug": {
@@ -4341,12 +4358,12 @@
           },
           "dependencies": {
             "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "^2.1.1"
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "core-js": "^3.20.3",
     "cssnano": "^5.0.15",
     "csso": "^4.2.0",
-    "dcf": "git://github.com/jsturek/dcf.git#bg-video-toggle",
+    "dcf": "git://github.com/digitalcampusframework/dcf.git#3.0",
     "decompress": "^4.2.1",
     "follow-redirects": "^1.14.7",
     "fsevents": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "core-js": "^3.20.3",
     "cssnano": "^5.0.15",
     "csso": "^4.2.0",
-    "dcf": "git://github.com/digitalcampusframework/dcf.git#3.0",
+    "dcf": "git://github.com/jsturek/dcf.git#bg-video-toggle",
     "decompress": "^4.2.1",
     "follow-redirects": "^1.14.7",
     "fsevents": "^2.3.2",

--- a/wdn/templates_5.3/js-src/bg-videos.babel.js
+++ b/wdn/templates_5.3/js-src/bg-videos.babel.js
@@ -1,0 +1,8 @@
+require(['dcf-bg-video-toggle'], function(DCFBgVideoToggleModule) {
+  const theme = new DCFBgVideoToggleModule.DCFBgVideoToggleTheme();
+  theme.setThemeVariable('toggleBtnClassList', [ 'dcf-btn-bg-video-toggle', 'dcf-btn', 'dcf-btn-primary', 'dcf-z-1', 'dcf-absolute', 'dcf-pin-bottom', 'dcf-pin-right', 'dcf-d-flex', 'dcf-ai-center', 'dcf-jc-center', 'dcf-mb-3', 'dcf-mr-3', 'dcf-h-7', 'dcf-w-7', 'dcf-p-0', 'dcf-circle' ]);
+  theme.setThemeVariable('togglePlayBtnInnerHTML', '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M21.759 11.577L2.786.077a.499.499 0 0 0-.759.428v23a.498.498 0 0 0 .5.5c.09 0 .18-.024.259-.072l18.973-11.5a.5.5 0 0 0 0-.856z"></path></svg>');
+  theme.setThemeVariable('togglePauseBtnInnerHTML', '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M10.5 0h-5C5.224 0 5 .224 5 .5v23C5 23.776 5.224 24 5.5 24h5c.276 0 .5-.224.5-.5v-23C11 .224 10.776 0 10.5 0zM18.5 0h-5C13.224 0 13 .224 13 .5v23c0 .276.224.5.5.5h5c.276 0 .5-.224.5-.5v-23C19 .224 18.776 0 18.5 0z"></path></svg>');
+  let bgVideoToggle = new DCFBgVideoToggleModule.DCFBgVideoToggle(theme);
+  bgVideoToggle.initialize();
+});

--- a/wdn/templates_5.3/js-src/main-wdn-plugins.babel.js
+++ b/wdn/templates_5.3/js-src/main-wdn-plugins.babel.js
@@ -11,7 +11,8 @@ define([
   'hover_intent',
   'cta-nav',
   'form_validation',
-  'qa'
+  'qa',
+  'bg-videos'
 ], function () {
   for (var i = 0, pluginCount = arguments.length; i < pluginCount; i++) {
     var pluginObj = arguments[i];


### PR DESCRIPTION
Note: Temporary points to my DCF PR for new/pending DCF feature: https://github.com/digitalcampusframework/dcf/pull/433

This is a start. I made some assumptions which may be wrong.
* Is automatically available on any WDN page
* attempts to add play/pause buttons to any element with class of `dcf-bg-video`
* uses localstorage to get state of playing/paused and defaults to play.
* should play/pause any video tag with `autoplay` and `muted` attributes.
* DCF Themeable I used play/pause svg markup from DCF slide show for now in both DCF and WDN. Either or both can be updated if want different.

Tested with
```
<div class="dcf-mt-6">
            <div class="dcf-bg-video dcf-ratio dcf-ratio-16x9">
                <video class="dcf-ratio-child dcf-obj-fit-cover" autoplay muted>
                    <source src="https://mediahub.unl.edu/uploads/fb61d31c-8a94-11ec-a5b6-005056832e99/media.mp4" type="video/mp4">
                    Your browser does not support the video tag.
                </video>
            </div>
        </div>
        <div class="dcf-mt-6">
            <div class="dcf-bg-video dcf-ratio dcf-ratio-16x9">
                <video class="dcf-ratio-child dcf-obj-fit-cover" autoplay muted>
                    <source src="https://mediahub.unl.edu/uploads/fb61d31c-8a94-11ec-a5b6-005056832e99/media.mp4" type="video/mp4">
                    Your browser does not support the video tag.
                </video>
            </div>
        </div>
```
