### PR TITLE
Remove progress width and max-width

### DIFF
--- a/wdn/templates_5.3/scss/elements/_elements.progress.scss
+++ b/wdn/templates_5.3/scss/elements/_elements.progress.scss
@@ -7,8 +7,6 @@
 .unl progress[value] {
   appearance: none; // Reset default appearance.
   border: none; // Get rid of default border in Firefox.
-  max-width: 100%;
-  width: 100%;
 }
 
 

--- a/wdn/templates_5.3/scss/elements/_elements.progress.scss
+++ b/wdn/templates_5.3/scss/elements/_elements.progress.scss
@@ -6,11 +6,11 @@
 // Styles for a determinate progress bar (one with a known value)
 .unl progress[value] {
   appearance: none; // Reset default appearance.
-  border: none; // Get rid of default border in Firefox.
+  border: none; // Remove default border in Firefox.
 }
 
 
-// Progress bar (background/container) and value -- WebKit only
+// Progress bar (background/container) -- WebKit only -- and value
 .unl progress[value]::-webkit-progress-bar,
 .unl progress[value]::-webkit-progress-value {
   border-radius: $pill;


### PR DESCRIPTION
Set `width` and/or `max-width` manually as needed rather than customize default.