### PR TITLE
Remove Security and Fire Safety Report link from footer

### DIFF
--- a/wdn/templates_5.3/includes/global/footer-global-2.html
+++ b/wdn/templates_5.3/includes/global/footer-global-2.html
@@ -22,7 +22,6 @@
           <li><a href="https://www.unl.edu/equity/notice-nondiscrimination">Notice of Nondiscrimination</a></li>
           <li><a href="https://its.unl.edu/unlprivacypolicy">Privacy Policy</a></li>
           <li><a href="https://safety.unl.edu/">Safety at Nebraska</a></li>
-          <li><a href="https://police.unl.edu/safety-reports-and-statistics#annual-report">Security and Fire Safety Report</a></li>
           <li><a href="https://heoa.unl.edu/">Student Information Disclosures</a></li>
         </ul>
       </div>


### PR DESCRIPTION
This link will be included on the Safety at Nebraska site (which immediately precedes it in the footer).