### PR TITLE
Add screen media query for colors in critical CSS

### DIFF
--- a/wdn/templates_5.3/scss/critical.scss
+++ b/wdn/templates_5.3/scss/critical.scss
@@ -1585,6 +1585,7 @@ a.dcf-btn-secondary {
 // .dcf-z-2 {
 //     z-index: 2!important;
 // }
+@media screen {
 .unl-bg-scarlet {
   background-color: #d00000!important;
 }
@@ -1783,6 +1784,7 @@ a.unl-cream:link {
 // .unl-darkest-gray {
 //     color: #242423!important;
 // }
+}
 .unl-font-serif-ltd-caps {
   font-family: Mercury SSm Ltd Caps A,Mercury SSm Ltd Caps B,Georgia,serif!important;
 }

--- a/wdn/templates_5.3/scss/critical.tmp.scss
+++ b/wdn/templates_5.3/scss/critical.tmp.scss
@@ -1668,6 +1668,7 @@ a.dcf-btn-secondary {
 // .dcf-z-2 {
 //     z-index: 2!important;
 // }
+@media screen {
 .unl-bg-scarlet {
   background-color: #d00000!important;
 }
@@ -1866,6 +1867,7 @@ a.unl-cream:link {
 // .unl-darkest-gray {
 //     color: #242423!important;
 // }
+}
 .unl-font-serif-ltd-caps {
   font-family: Mercury SSm Ltd Caps A,Mercury SSm Ltd Caps B,Georgia,serif!important;
 }


### PR DESCRIPTION
Add `@media screen` media query (already present in main.css) to critical.css for colors and background colors in print.