### PR TITLE
Fix info and success notice color contrast

### DIFF
--- a/wdn/templates_5.3/scss/variables/_variables.notices.scss
+++ b/wdn/templates_5.3/scss/variables/_variables.notices.scss
@@ -14,8 +14,8 @@ $bg-color-notice-danger: $danger;       // Danger notice background-color
 
 
 // Color
-$color-notice-info: $light-blue;        // Info notice color
-$color-notice-success: $light-green;    // Success notice color
+$color-notice-info: $lighter-blue;      // Info notice color
+$color-notice-success: $lighter-green;  // Success notice color
 $color-notice-warning: $cream;          // Warning notice color
 $color-notice-danger: $scarlet-tint;    // Danger notice color
 


### PR DESCRIPTION
Lighten text color for _info_ and _success_ notices.

Closes #1620 