### PR TITLE
Move dark-mode-only colors and background-colors into dark mode media queries 

### DIFF
--- a/wdn/templates_5.3/scss/utilities/_utilities.background-colors.scss
+++ b/wdn/templates_5.3/scss/utilities/_utilities.background-colors.scss
@@ -11,16 +11,12 @@
 
   // Cream
   .unl-bg-cream { @include bg-cream(!important); }
-  .unl-bg-cream\@dark { @include bg-cream-at-dark(!important); }
 
 
   // Gray
   .unl-bg-lightest-gray { @include bg-lightest(!important); }
-  .unl-bg-lightest-gray\@dark { @include bg-lightest-at-dark(!important); }
   .unl-bg-lighter-gray { @include bg-lighter(!important); }
-  .unl-bg-lighter-gray\@dark { @include bg-lighter-at-dark(!important); }
   .unl-bg-light-gray { @include bg-light(!important); }
-  .unl-bg-light-gray\@dark { @include bg-light-at-dark(!important); }
   .unl-bg-dark-gray { @include bg-dark(!important); }
   .unl-bg-darker-gray { @include bg-darker(!important); }
   .unl-bg-darkest-gray { @include bg-darkest(!important); }
@@ -33,22 +29,45 @@
   // Green
   .unl-bg-green { @include bg-green(!important); }
   .unl-bg-light-green { @include bg-light-green(!important); }
-  .unl-bg-light-green\@dark { @include bg-light-green-at-dark(!important); }
 
 
   // Blue
   .unl-bg-blue { @include bg-blue(!important); }
   .unl-bg-light-blue { @include bg-light-blue(!important); }
-  .unl-bg-light-blue\@dark { @include bg-light-blue-at-dark(!important); }
 
 
   // Purple
   .unl-bg-purple { @include bg-purple(!important); }
   .unl-bg-light-purple { @include bg-light-purple(!important); }
-  .unl-bg-light-purple\@dark { @include bg-light-purple-at-dark(!important); }
 
 
   // Yellow
   .unl-bg-yellow { @include bg-yellow(!important); }
+
+}
+
+
+@media screen and (prefers-color-scheme: dark) {
+
+  // Cream
+  .unl-bg-cream\@dark { @include bg-cream-at-dark(!important); }
+
+
+  // Gray
+  .unl-bg-lightest-gray\@dark { @include bg-lightest-at-dark(!important); }
+  .unl-bg-lighter-gray\@dark { @include bg-lighter-at-dark(!important); }
+  .unl-bg-light-gray\@dark { @include bg-light-at-dark(!important); }
+
+
+  // Green
+  .unl-bg-light-green\@dark { @include bg-light-green-at-dark(!important); }
+
+
+  // Blue
+  .unl-bg-light-blue\@dark { @include bg-light-blue-at-dark(!important); }
+
+
+  // Purple
+  .unl-bg-light-purple\@dark { @include bg-light-purple-at-dark(!important); }
 
 }

--- a/wdn/templates_5.3/scss/utilities/_utilities.colors.scss
+++ b/wdn/templates_5.3/scss/utilities/_utilities.colors.scss
@@ -35,11 +35,8 @@
   .unl-light-gray { @include light-gray(!important); }
   .unl-gray { @include gray(!important); }
   .unl-dark-gray { @include dark-gray(!important); }
-  .unl-dark-gray\@dark { @include dark-gray-at-dark(!important); }
   .unl-darker-gray { @include darker-gray(!important); }
-  .unl-darker-gray\@dark { @include darker-gray-at-dark(!important); }
   .unl-darkest-gray { @include darkest-gray(!important); }
-  .unl-darkest-gray\@dark { @include darkest-gray-at-dark(!important); }
 
 
   // Cerulean
@@ -48,23 +45,43 @@
 
   // Green
   .unl-green { @include green(!important); }
-  .unl-green\@dark { @include green-at-dark(!important); }
   .unl-light-green { @include light-green(!important); }
 
 
   // Blue
   .unl-blue { @include blue(!important); }
-  .unl-blue\@dark { @include blue-at-dark(!important); }
   .unl-light-blue { @include light-blue(!important); }
 
 
   // Purple
   .unl-purple { @include purple(!important); }
-  .unl-purple\@dark { @include purple-at-dark(!important); }
   .unl-light-purple { @include light-purple(!important); }
 
 
   // Yellow
   .unl-yellow { @include yellow(!important); }
+
+}
+
+
+
+@media screen and (prefers-color-scheme: dark) {
+
+  // Gray
+  .unl-dark-gray\@dark { @include dark-gray-at-dark(!important); }
+  .unl-darker-gray\@dark { @include darker-gray-at-dark(!important); }
+  .unl-darkest-gray\@dark { @include darkest-gray-at-dark(!important); }
+
+
+  // Green
+  .unl-green\@dark { @include green-at-dark(!important); }
+
+
+  // Blue
+  .unl-blue\@dark { @include blue-at-dark(!important); }
+
+
+  // Purple
+  .unl-purple\@dark { @include purple-at-dark(!important); }
 
 }


### PR DESCRIPTION
Color and background classes that are dark-mode-specific (`@dark`) will no longer apply to both dark mode _and_ light mode. Instead, they will apply only to dark mode – as their name implies. Chaining classes together (e.g., `unl-bg-cream unl-bg-cream@dark`) achieves the previous result.