### PR TITLE
Remove COVID-19 header link(s)

### DIFF
--- a/wdn/templates_5.3/includes/global/cta-header-1.html
+++ b/wdn/templates_5.3/includes/global/cta-header-1.html
@@ -1,4 +1,1 @@
-<div class="dcf-w-100% dcf-txt-right unl-div-cta-covid">
-  <a class="dcf-d-inline-block dcf-txt-2xs dcf-pt-3 dcf-pb-4 dcf-pl-6 unl-link-cta-covid dcf-d-none@print" href="https://covid19.unl.edu/">COVID-19</a>
-</div>
 <ul class="dcf-list-bare dcf-cta dcf-cta-header dcf-header-global-item dcf-jc-flex-end dcf-mb-0 dcf-txt-2xs dcf-d-none@print">

--- a/wdn/templates_5.3/includes/global/logo-lockup-1.html
+++ b/wdn/templates_5.3/includes/global/logo-lockup-1.html
@@ -1,4 +1,4 @@
-<div class="dcf-logo-lockup dcf-wrapper dcf-d-flex dcf-ai-flex-end dcf-relative dcf-overflow-hidden" id="dcf-logo-lockup">
+<div class="dcf-logo-lockup dcf-wrapper dcf-d-flex dcf-ai-flex-end dcf-relative dcf-overflow-hidden dcf-pt-5" id="dcf-logo-lockup">
   <a class="dcf-header-logo dcf-mr-4 dcf-flex-shrink-0" id="dcf-header-logo" href="https://www.unl.edu/" aria-label="Go to University of Nebraska–Lincoln home page">
     <svg class="dcf-d-block dcf-h-8 dcf-w-8" focusable="false" height="76" width="76" viewBox="0 0 152 152">
       <defs>

--- a/wdn/templates_5.3/includes/global/visit-header-1.html
+++ b/wdn/templates_5.3/includes/global/visit-header-1.html
@@ -1,6 +1,3 @@
-<li class="dcf-mb-0">
-  <a class="dcf-d-inline-block dcf-p-4 unl-link-cta-covid" href="https://covid19.unl.edu/">COVID-19</a>
-</li>
 <li class="dcf-relative dcf-mb-0">
   <a class="dcf-link-cta dcf-p-4" href="https://www.unl.edu/visitor/">Visit</a>
   <button class="dcf-btn-toggle-cta dcf-p-4 dcf-bg-transparent dcf-b-0" id="dcf-visit-toggle" aria-pressed="false" aria-haspopup="true" aria-controls="dcf-visit-options" hidden>Visit</button>

--- a/wdn/templates_5.3/scss/components/_components.header.scss
+++ b/wdn/templates_5.3/scss/components/_components.header.scss
@@ -67,7 +67,6 @@
 
   .unl .dcf-logo-lockup {
     padding-bottom: #{ms(1)}em;
-    @include pt-5;
   }
 
   .unl-div-cta-covid {

--- a/wdn/templates_5.3/scss/components/_components.header.scss
+++ b/wdn/templates_5.3/scss/components/_components.header.scss
@@ -69,31 +69,4 @@
     padding-bottom: #{ms(1)}em;
   }
 
-  .unl-div-cta-covid {
-    display: none;
-  }
-
-}
-
-
-.dcf-header .unl-link-cta-covid {
-  color: $blue;
-}
-
-.dcf-header .unl-link-cta-covid:hover {
-  color: $dark-blue;
-}
-
-
-
-@media (prefers-color-scheme: dark) {
-
-  .dcf-header .unl-link-cta-covid {
-    color: $light-cerulean;
-  }
-
-  .dcf-header .unl-link-cta-covid:hover {
-    color: $cerulean;
-  }
-
 }

--- a/wdn/templates_5.3/scss/critical.scss
+++ b/wdn/templates_5.3/scss/critical.scss
@@ -1938,7 +1938,6 @@ a.unl-cream:link {
   }
   .unl .dcf-logo-lockup {
     padding-bottom: 1em;
-    padding-top: 1.33em;
   }
   .unl-site-title a {
     font-size: 1em;
@@ -2064,8 +2063,7 @@ a.unl-cream:link {
     font-size: 2.37em!important;
   }
   .unl .dcf-nav-toggle-group,
-  .unl .dcf-cta-nav,
-  .unl-div-cta-covid {
+  .unl .dcf-cta-nav {
     display: none;
   }
 }

--- a/wdn/templates_5.3/scss/critical.tmp.scss
+++ b/wdn/templates_5.3/scss/critical.tmp.scss
@@ -2022,7 +2022,6 @@ a.unl-cream:link {
   }
   .unl .dcf-logo-lockup {
     padding-bottom: 1em;
-    padding-top: 1.33em;
   }
   .unl-site-title a {
     font-size: 1em;
@@ -2148,8 +2147,7 @@ a.unl-cream:link {
     font-size: 2.37em!important;
   }
   .unl .dcf-nav-toggle-group,
-  .unl .dcf-cta-nav,
-  .unl-div-cta-covid {
+  .unl .dcf-cta-nav {
     display: none;
   }
 }


### PR DESCRIPTION
- Remove mobile and desktop versions of COVID-19 header link
- Restore `padding-top` to logo lockup that was removed for COVID-19 link since it occupied the (roughly) equivalent vertical space.
- Remove custom `padding-top` now handled by utility class in the logo lockup.