### PR TITLE
Bumped dcf version to current 3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3350,7 +3350,7 @@
       "dev": true
     },
     "dcf": {
-      "version": "git+ssh://git@github.com/digitalcampusframework/dcf.git#1cf246eae7e6b1ac1fb14fe26c66c4da49ac4d6e",
+      "version": "git+ssh://git@github.com/digitalcampusframework/dcf.git#564ee727a9236ba06a7440e4568eb08c7beafa74",
       "from": "git+ssh://git@github.com/digitalcampusframework/dcf.git#3.0",
       "dev": true
     },


### PR DESCRIPTION
Bumped version of DCF in package-lock from old version

[Old Version](https://github.com/digitalcampusframework/dcf/commit/1cf246eae7e6b1ac1fb14fe26c66c4da49ac4d6e)
[New Version](https://github.com/digitalcampusframework/dcf/commit/564ee727a9236ba06a7440e4568eb08c7beafa74)