### PR TITLE
Adjust light background-colors for dark mode

### DIFF
--- a/wdn/templates_5.3/scss/variables/_variables.backgrounds.scss
+++ b/wdn/templates_5.3/scss/variables/_variables.backgrounds.scss
@@ -44,7 +44,7 @@ $bg-color-white-dark-mode: $darker-gray-s1;                       // White backg
 $bg-color-white: var(--bg-white);
 
 $bg-color-gray-light-light-mode: $light-gray;                     // Light gray background-color in light mode
-$bg-color-gray-light-dark-mode: $darker-gray-s2;                  // Light gray background-color in dark mode
+$bg-color-gray-light-dark-mode: $darker-gray-s4;                  // Light gray background-color in dark mode
 $bg-color-gray-light: var(--bg-light-gray);
 
 $bg-color-gray-lighter-light-mode: $lighter-gray;                 // Lighter gray background-color in light mode
@@ -52,7 +52,7 @@ $bg-color-gray-lighter-dark-mode: $darker-gray-s3;                // Lighter gra
 $bg-color-gray-lighter: var(--bg-lighter-gray);
 
 $bg-color-gray-lightest-light-mode: $lightest-gray;               // Lightest gray background-color in light mode
-$bg-color-gray-lightest-dark-mode: $darker-gray-s4;               // Lightest gray background-color in dark mode
+$bg-color-gray-lightest-dark-mode: $darker-gray-s2;               // Lightest gray background-color in dark mode
 $bg-color-gray-lightest: var(--bg-lightest-gray);
 
 $bg-color-inverse-light-mode: $color-body-light-mode;             // Inverse background-color in light mode

--- a/wdn/templates_5.3/scss/variables/_variables.cards.scss
+++ b/wdn/templates_5.3/scss/variables/_variables.cards.scss
@@ -10,7 +10,7 @@
 
 // Background color
 $bg-color-card-light-mode: $cream;          // Card background-color in light mode
-$bg-color-card-dark-mode: $darker-gray-s1;  // Card background-color in dark mode
+$bg-color-card-dark-mode: $darker-gray;     // Card background-color in dark mode
 $bg-color-card: var(--bg-card);
 
 


### PR DESCRIPTION
- Lighten `.dcf-card` `background-color`
- Swap values for `.unl-bg-light-gray` and `.unl-bg-lightest-gray` (`.unl-bg-light-gray` now uses the hex color for `.unl-bg-lightest-gray` and vice versa). Class names will now be accurate – `lightest` will no longer be darker than `light`.