### PR TITLE
Fix scarlet link state colors in dark mode

### DIFF
--- a/wdn/templates_5.3/scss/mixins/_mixins.colors.scss
+++ b/wdn/templates_5.3/scss/mixins/_mixins.colors.scss
@@ -5,10 +5,9 @@
 
 // Scarlet
 @mixin scarlet($imp:null) { color: $color-brand-alpha $imp; }
-// TODO: determine state styles
-@mixin scarlet-visited($imp:null) { color: $scarlet $imp; }
-@mixin scarlet-hover($imp:null) { color: $scarlet $imp; }
-@mixin scarlet-active($imp:null) { color: $scarlet $imp; }
+@mixin scarlet-visited($imp:null) { color: $color-brand-alpha $imp; }
+@mixin scarlet-hover($imp:null) { color: $color-brand-alpha $imp; }
+@mixin scarlet-active($imp:null) { color: $color-brand-alpha $imp; }
 
 
 // Cream

--- a/wdn/templates_5.3/scss/mixins/_mixins.colors.scss
+++ b/wdn/templates_5.3/scss/mixins/_mixins.colors.scss
@@ -5,9 +5,6 @@
 
 // Scarlet
 @mixin scarlet($imp:null) { color: $color-brand-alpha $imp; }
-@mixin scarlet-visited($imp:null) { color: $color-brand-alpha $imp; }
-@mixin scarlet-hover($imp:null) { color: $color-brand-alpha $imp; }
-@mixin scarlet-active($imp:null) { color: $color-brand-alpha $imp; }
 
 
 // Cream

--- a/wdn/templates_5.3/scss/utilities/_utilities.colors.scss
+++ b/wdn/templates_5.3/scss/utilities/_utilities.colors.scss
@@ -8,14 +8,12 @@
   // Scarlet
   .unl-scarlet,
   a.unl-scarlet,
-  a.unl-scarlet:link {
+  a.unl-scarlet:link,
+  a.unl-scarlet:visited,
+  a.unl-scarlet:hover,
+  a.unl-scarlet:active {
     @include scarlet(!important);
   }
-
-  a.unl-scarlet:visited { @include scarlet-visited(!important); }
-  a.unl-scarlet:hover { @include scarlet-hover(!important); }
-  a.unl-scarlet:active { @include scarlet-active(!important); }
-
 
   // Cream
   .unl-cream,


### PR DESCRIPTION
When `.unl-scarlet` is applied to a link, the `:visited`, `:hover` and `:active` states inherit the link state colors. This means the link is ~~cream~~ lightest-gray by default, but scarlet on `:hover`. Now the ~~cream~~ lightest-gray color is consistent across all states.