### PR TITLE
Add background diagonal gradients mixin/utility

### DIFF
--- a/wdn/templates_5.3/scss/mixins/_mixins.background-images.scss
+++ b/wdn/templates_5.3/scss/mixins/_mixins.background-images.scss
@@ -58,6 +58,12 @@
 }
 
 
+// Diagonal Gradients
+@mixin bg-diagonal-gradients($imp:null) {
+  background-image: linear-gradient($diagonal1, $black, fade-out($black,.75) 24%, fade-out($black,.25) 24%, transparent 32%, fade-out($black,.5) 32%, fade-out($black,.75) 75%, fade-out($black,.25) 75%, fade-out($black,.75) 84%, fade-out($black,.25) 84%, transparent);
+}
+
+
 // SVG Background Pattern: Campus
 @mixin bg-campus($imp:null) {
   background-image: url('../images/bg-campus.svg') $imp;

--- a/wdn/templates_5.3/scss/utilities/_utilities.background-images.scss
+++ b/wdn/templates_5.3/scss/utilities/_utilities.background-images.scss
@@ -25,6 +25,10 @@
 .unl-bg-stripes-light { @include bg-stripes-light(!important); }
 
 
+// Diagonal Gradients
+.unl-bg-diagonal-gradients { @include bg-diagonal-gradients(!important); }
+
+
 // SVG Background Pattern: Campus
 .unl-bg-campus { @include bg-campus(!important); }
 


### PR DESCRIPTION
Diagonal gradient background image can be added atop any framework `background-color` with a combination of the `unl-bg-diagonal-gradients` and `unl-bg-soft-light` utility classes.