### PR TITLE
Adjust modal-wrapper max-height

### DIFF
--- a/wdn/templates_5.3/scss/variables/_variables.modals.scss
+++ b/wdn/templates_5.3/scss/variables/_variables.modals.scss
@@ -4,6 +4,7 @@
 
 
 @import '_variables.body';
+@import '_variables.sizing';
 
 
 // Background color
@@ -17,5 +18,5 @@ $bg-color-modal-header: var(--bg-body);
 
 
 // Height & width
-$height-max-modal-wrapper: 75vh;                                // Max-height modal wrapper
+$height-max-modal-wrapper: calc(100% - (2 * #{$length-em-4}));  // Max-height modal wrapper
 $width-modal-wrapper: calc(100% - (2 * #{ms(12)}vw));           // Match width of .dcf-wrapper

--- a/wdn/templates_5.3/scss/variables/_variables.modals.scss
+++ b/wdn/templates_5.3/scss/variables/_variables.modals.scss
@@ -18,5 +18,5 @@ $bg-color-modal-header: var(--bg-body);
 
 
 // Height & width
-$height-max-modal-wrapper: calc(100% - (2 * #{$length-em-4}));  // Max-height modal wrapper
+$height-max-modal-wrapper: calc(100vh - (2 * #{$length-em-4})); // Max-height modal wrapper
 $width-modal-wrapper: calc(100% - (2 * #{ms(12)}vw));           // Match width of .dcf-wrapper


### PR DESCRIPTION
Increase modal-wrapper `max-height` to use more available screen real estate.