### PR TITLE
Convert form validator icon font to Unicode

### DIFF
--- a/wdn/templates_5.3/js-src/js-css/formvalidator.scss
+++ b/wdn/templates_5.3/js-src/js-css/formvalidator.scss
@@ -11,18 +11,11 @@ ul.validation-advice {
 
 
 ul.validation-advice li::before {
-  content: '\e80f';
+  content: '\2191';
   display: inline-block;
-  font-family: 'wdn-icon';
-  font-style: normal;
-  font-weight: normal;
   margin-right: .2em;
   text-align: center;
-  text-decoration: inherit;
   width: 1em;
-  // For safety - reset parent styles, that can break glyph codes
-  font-variant: normal;
-  text-transform: none;
 }
 
 


### PR DESCRIPTION
Replace icon font with upwards arrow Unicode glyph. Removing the icon font brings us one step closer to removing it as a dependency.