### PR TITLE
Added time mode support

### DIFF
--- a/wdn/templates_5.3/js-src/events.babel.js
+++ b/wdn/templates_5.3/js-src/events.babel.js
@@ -133,15 +133,15 @@ define([
     let time     = '';
 
     if (event.DateTime.AllDay) {
-      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${startDate.format('HH:mm')}">${timeIcon} All Day</time>`;
+      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center" datetime="${startDate.format('HH:mm')}">${timeIcon} All Day</time>`;
     } else if (event.DateTime.TimeMode === 'TBD') {
-      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${startDate.format('HH:mm')}">${timeIcon} <abbr title="To Be Determined">TBD</abbr></time>`;
+      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center" datetime="${startDate.format('HH:mm')}">${timeIcon} <abbr title="To Be Determined">TBD</abbr></time>`;
     } else if (event.DateTime.TimeMode === 'STARTTIMEONLY') {
-      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${startDate.format('HH:mm')}">${timeIcon} Starts at ${startDate.format(timeformat)}</time>`;
+      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center" datetime="${startDate.format('HH:mm')}">${timeIcon} Starts at ${startDate.format(timeformat)}</time>`;
     } else if (event.DateTime.TimeMode === 'ENDTIMEONLY') {
-      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${endDate.format('HH:mm')}">${timeIcon} Ends at ${endDate.format(timeformat)}</time>`;
+      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center" datetime="${endDate.format('HH:mm')}">${timeIcon} Ends at ${endDate.format(timeformat)}</time>`;
     } else {
-      time = `<div class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase">${timeIcon}<time datetime="${startDate.format('HH:mm')}">${startDate.format(timeformat)}</time>`;
+      time = `<div class="unl-event-time dcf-d-flex dcf-ai-center">${timeIcon}<time datetime="${startDate.format('HH:mm')}">${startDate.format(timeformat)}</time>`;
       if (endDate !== undefined && endDate.unix() > startDate.unix()) {
         time += `&nbsp;&ndash;&nbsp;<time datetime="${endDate.format('HH:mm')}">${endDate.format(timeformat)}</time>`;
       }

--- a/wdn/templates_5.3/js-src/events.babel.js
+++ b/wdn/templates_5.3/js-src/events.babel.js
@@ -131,8 +131,17 @@ define([
     let day      = `<span class="dcf-d-block dcf-txt-h5 dcf-bold dcf-br-1 dcf-bb-1 dcf-bl-1 dcf-br-solid dcf-bb-solid dcf-bl-solid unl-br-light-gray unl-bb-light-gray unl-bl-light-gray unl-darker-gray dcf-bg-white">${startDate.format('D')}</span>`;
     let date     = `<time class="unl-event-date dcf-flex-shrink-0 dcf-w-8 dcf-txt-center" datetime="${startDate.format('YYYY-MM-DD')}">${month}${day}</time>`;
     let time     = '';
+
+    console.log(event.DateTime.TimeMode);
+
     if (event.DateTime.AllDay) {
       time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${startDate.format('HH:mm')}">${timeIcon} All Day</time>`;
+    } else if (event.DateTime.TimeMode === 'TBD') {
+      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${startDate.format('HH:mm')}">${timeIcon} <abbr title="To Be Determined">TBD</abbr></time>`;
+    } else if (event.DateTime.TimeMode === 'STARTTIMEONLY') {
+      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${startDate.format('HH:mm')}">${timeIcon} Starts at ${startDate.format(timeformat)}</time>`;
+    } else if (event.DateTime.TimeMode === 'ENDTIMEONLY') {
+      time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${endDate.format('HH:mm')}">${timeIcon} Ends at ${endDate.format(timeformat)}</time>`;
     } else {
       time = `<div class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase">${timeIcon}<time datetime="${startDate.format('HH:mm')}">${startDate.format(timeformat)}</time>`;
       if (endDate !== undefined && endDate.unix() > startDate.unix()) {

--- a/wdn/templates_5.3/js-src/events.babel.js
+++ b/wdn/templates_5.3/js-src/events.babel.js
@@ -132,8 +132,6 @@ define([
     let date     = `<time class="unl-event-date dcf-flex-shrink-0 dcf-w-8 dcf-txt-center" datetime="${startDate.format('YYYY-MM-DD')}">${month}${day}</time>`;
     let time     = '';
 
-    console.log(event.DateTime.TimeMode);
-
     if (event.DateTime.AllDay) {
       time = `<time class="unl-event-time dcf-d-flex dcf-ai-center dcf-uppercase" datetime="${startDate.format('HH:mm')}">${timeIcon} All Day</time>`;
     } else if (event.DateTime.TimeMode === 'TBD') {


### PR DESCRIPTION
This goes along with [events#209](https://github.com/unl/UNL_Events/pull/209)

Changes:

- Events with time mode 'TBD' will be displayed as `TBD` (This includes the abbr tag)
- Events with time mode 'STARTTIMEONLY' will be displayed with `Starts at`
- Events with time mode 'ENDTIMEONLY' will be displayed with `Ends at`