### PR TITLE
Remove modal style overrides

### DIFF
--- a/wdn/templates_5.3/scss/components/_components.modals.scss
+++ b/wdn/templates_5.3/scss/components/_components.modals.scss
@@ -12,16 +12,3 @@
 .unl .dcf-modal[aria-hidden="false"] {
   transition: opacity $transition-duration-fade-in $transition-timing-fn-fade-in;
 }
-
-
-// Modal Wrapper
-.unl .dcf-modal-wrapper {
-  max-height: 75vh;
-  width: calc(100% - (2 * #{ms(12)}vw)); // Match width of .dcf-wrapper
-}
-
-
-// Modal Content
-.unl .dcf-modal-content > *:last-child {
-  margin-bottom: 0;
-}


### PR DESCRIPTION
These styles are unnecessary. They're already handled by [DCF](https://github.com/digitalcampusframework/dcf/blob/3.0/scss/components/_components.modals.scss).