### PR TITLE
Add `bg-color-foreground` variable/mixin/utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wdntemplates",
-  "version": "5.3.46",
+  "version": "5.3.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wdntemplates",
-      "version": "5.3.46",
+      "version": "5.3.47",
       "license": "BSD-3-Clause",
       "dependencies": {
         "axe-core": "^4.3.5",
@@ -4389,7 +4389,7 @@
     },
     "node_modules/dcf": {
       "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/digitalcampusframework/dcf.git#a6641d9a3d9fdf0bb40b1a43be3fdbafa718313f",
+      "resolved": "git+ssh://git@github.com/digitalcampusframework/dcf.git#79fbe7e343792105750fe0b4d80c5f646c686b65",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/wdn/templates_5.3/scss/variables/_variables.backgrounds.scss
+++ b/wdn/templates_5.3/scss/variables/_variables.backgrounds.scss
@@ -70,3 +70,5 @@ $bg-color-overlay-light: var(--bg-overlay-light);
 $bg-color-dialog-light-mode: $white;                              // Dialog background-color in light mode
 $bg-color-dialog-dark-mode: $darker-gray-s1;                      // Dialog background-color in dark mode
 $bg-color-dialog: var(--bg-dialog);
+
+$bg-color-foreground: var(--bg-dialog);


### PR DESCRIPTION
For use with elements (e.g., cards, tab panels, dialogs) to "foreground" them above other elements by setting the `background-color` to white in light mode and a dark gray lighter than any other background colors in dark mode.

- Add `$bg-color-foreground` variable
- Pairs with [DCF 526](https://github.com/digitalcampusframework/dcf/pull/526) which adds mixin/utility class.