### PR TITLE
Remove `.unl` class before paragraph and list selectors in critical CSS

### DIFF
--- a/wdn/templates_5.3/scss/critical.scss
+++ b/wdn/templates_5.3/scss/critical.scss
@@ -215,6 +215,9 @@ figure {
     font-size: 1.33em;
   }
 }
+
+
+// !Elements
 // a {
 //   -webkit-text-decoration-skip: ink;
 //   text-decoration-skip: ink;
@@ -299,6 +302,12 @@ p {
   margin-bottom: 1rem;
   margin-top: 0;
 }
+p,
+dl,
+ol,
+ul {
+  text-wrap: pretty;
+}
 // body:lang(en) {
 //   quotes: "“" "”" "‘" "’" "“" "”" "‘" "’";
 // }
@@ -323,15 +332,6 @@ p {
 // sub {
 //   top: .24em;
 // }
-
-
-// !Elements
-.unl dl,
-.unl ol,
-.unl p,
-.unl ul {
-  text-wrap: pretty;
-}
 
 
 // !Objects

--- a/wdn/templates_5.3/scss/critical.tmp.scss
+++ b/wdn/templates_5.3/scss/critical.tmp.scss
@@ -307,6 +307,9 @@ figure {
     font-size: 1.33em;
   }
 }
+
+
+// !Elements
 // a {
 //   -webkit-text-decoration-skip: ink;
 //   text-decoration-skip: ink;
@@ -391,6 +394,12 @@ p {
   margin-bottom: 1rem;
   margin-top: 0;
 }
+p,
+dl,
+ol,
+ul {
+  text-wrap: pretty;
+}
 // body:lang(en) {
 //   quotes: "“" "”" "‘" "’" "“" "”" "‘" "’";
 // }
@@ -415,15 +424,6 @@ p {
 // sub {
 //   top: .24em;
 // }
-
-
-// !Elements
-.unl dl,
-.unl ol,
-.unl p,
-.unl ul {
-  text-wrap: pretty;
-}
 
 
 // !Objects


### PR DESCRIPTION
The `.unl` class is unnecessary. By removing the class, the critical CSS will match the styles in DCF core for [paragraphs](https://github.com/digitalcampusframework/dcf/blob/3.0/scss/elements/_elements.paragraphs.scss#L6-L12) and [lists](https://github.com/digitalcampusframework/dcf/blob/3.0/scss/elements/_elements.lists.scss#L12-L19).