### PR TITLE
Adjust local nav grid columns to allow for better text wrapping

### DIFF
--- a/wdn/templates_5.3/scss/components/_components.nav-local.scss
+++ b/wdn/templates_5.3/scss/components/_components.nav-local.scss
@@ -52,7 +52,7 @@
 @include mq(md, min, width) {
 
   .unl .dcf-nav-local > ul:first-child {
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(6, auto);
     overflow: hidden;
     width: 100%;
   }


### PR DESCRIPTION
Adjust local nav column widths to use `auto` instead of `1fr`. Thanks, @badrobotbrain!

Closes #1752