### PR TITLE
Revert local nav column widths to `1fr`

### DIFF
--- a/wdn/templates_5.3/scss/components/_components.nav-local.scss
+++ b/wdn/templates_5.3/scss/components/_components.nav-local.scss
@@ -52,7 +52,7 @@
 @include mq(md, min, width) {
 
   .unl .dcf-nav-local > ul:first-child {
-    grid-template-columns: repeat(6, auto);
+    grid-template-columns: repeat(6, 1fr);
     overflow: hidden;
     width: 100%;
   }


### PR DESCRIPTION
Undo #1774. See first column ("About") of [College of Engineering](https://engineering.unl.edu/) website navigation.