### PR TITLE
Fix absolute paths and copy dcf files to wdn/templates_5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /node_modules
 /vagrant/dev/.vagrant
 /wdn/templates_*/css
+/wdn/templates_*/dcf
 /wdn/templates_*/scss/components/_components.dev.scss
 /wdn/templates_*/js/compressed
 /wdn/templates_*/scripts/compressed

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -581,8 +581,8 @@ module.exports = function (grunt) {
 
     files.forEach(function(file) {
       let content = grunt.file.read(file);
-      let newContent = content.replace(/(file:\/\/\/[a-zA-Z0-9_\-\/\.]+\/wdn)+/g, '/wdn'); // Replace globally
-      let newNewContent = newContent.replace(/(file:\/\/\/[a-zA-Z0-9_\-\/\.]+\/dcf)+/g, '/wdn/templates_5.3/dcf'); // Replace globally
+      let newContent = content.replace(/(file:\/\/\/[^'",]+\/wdn)+/g, '/wdn'); // Replace globally
+      let newNewContent = newContent.replace(/(file:\/\/\/[^'",]+\/dcf)+/g, '/wdn/templates_5.3/dcf'); // Replace globally
       
       // Write the updated content back to the file
       grunt.file.write(file, newNewContent);


### PR DESCRIPTION
Dart sass uses the absolute paths for source maps. This leaves us with `file://...` for all css source maps file references. These end up breaking when deployed to production. This PR fixes those source map references and adds the DCF files to the `wdn/templates_5.3` to reference them