### PR TITLE
Add `overflow-x: clip` to nav menu

### DIFF
--- a/wdn/templates_5.3/scss/components/_components.nav-menu.scss
+++ b/wdn/templates_5.3/scss/components/_components.nav-menu.scss
@@ -98,6 +98,7 @@
     @include bg-scarlet;
     display: flex;
     flex-wrap: nowrap;
+    overflow-x: clip;
     padding-left: $length-vw-2;
     padding-right: $length-vw-2;
   }


### PR DESCRIPTION
When menu is open, it extends past the viewport and allows for unwanted scrolling to the right in Safari 18.2. The behavior is illustrated by the following screenshot:

![Screenshot 2025-02-21 at 9 33 13 AM](https://github.com/user-attachments/assets/8a2b4abd-3a2f-4110-a501-778f6bd22e1a)

Applying `overflow-x: clip` to nav menu prevents this behavior.