### PR TITLE
Add background “shift” variables, mixins and utlities

### DIFF
--- a/wdn/templates_6.0/scss/mixins/_background-images.scss
+++ b/wdn/templates_6.0/scss/mixins/_background-images.scss
@@ -6,6 +6,27 @@
 @use "../variables/" as var;
 
 
+// Shifts
+@mixin bg-shift-top($imp:null) {
+  background-image: linear-gradient(180deg, transparent var.$bg-shift-size, var(--bg-shift-color) var.$bg-shift-size) $imp;
+}
+
+
+@mixin bg-shift-bottom($imp:null) {
+  background-image: linear-gradient(180deg, var(--bg-shift-color) calc(100% - var.$bg-shift-size), transparent calc(100% - var.$bg-shift-size)) $imp;
+}
+
+
+@mixin bg-shift-cream         { --bg-shift-color: var(--bg-body); }
+@mixin bg-shift-lightest-gray { --bg-shift-color: var(--bg-lightest-gray); }
+@mixin bg-shift-lighter-gray  { --bg-shift-color: var(--bg-lighter-gray); }
+@mixin bg-shift-light-gray    { --bg-shift-color: var(--bg-light-gray); }
+@mixin bg-shift-dark-gray     { --bg-shift-color: #{var.$dark-gray}; }
+@mixin bg-shift-darker-gray   { --bg-shift-color: #{var.$darker-gray}; }
+@mixin bg-shift-darkest-gray  { --bg-shift-color: #{var.$darkest-gray}; }
+@mixin bg-shift-scarlet       { --bg-shift-color: #{var.$bg-color-brand-alpha}; }
+
+
 // Dots
 @mixin bg-dots($imp:null) {
   background-size: #{var.$ms-4}rem $imp; // .56rem

--- a/wdn/templates_6.0/scss/utilities/_background-images.scss
+++ b/wdn/templates_6.0/scss/utilities/_background-images.scss
@@ -6,6 +6,67 @@
 @use "../mixins/" as mixins;
 
 
+// Shifts
+[class^="unl-bg-shift-top-"],
+[class*="unl-bg-shift-top-"] {
+  @include mixins.bg-shift-top;
+}
+
+
+[class^="unl-bg-shift-bottom-"],
+[class*="unl-bg-shift-bottom-"] {
+  @include mixins.bg-shift-bottom;
+}
+
+
+.unl-bg-shift-top-cream,
+.unl-bg-shift-bottom-cream {
+  @include mixins.bg-shift-cream;
+}
+
+
+.unl-bg-shift-top-lightest-gray,
+.unl-bg-shift-bottom-lightest-gray {
+  @include mixins.bg-shift-lightest-gray;
+}
+
+
+.unl-bg-shift-top-lighter-gray,
+.unl-bg-shift-bottom-lighter-gray {
+  @include mixins.bg-shift-lighter-gray;
+}
+
+
+.unl-bg-shift-top-light-gray,
+.unl-bg-shift-bottom-light-gray {
+  @include mixins.bg-shift-light-gray;
+}
+
+
+.unl-bg-shift-top-dark-gray,
+.unl-bg-shift-bottom-dark-gray {
+  @include mixins.bg-shift-dark-gray;
+}
+
+
+.unl-bg-shift-top-darker-gray,
+.unl-bg-shift-bottom-darker-gray {
+  @include mixins.bg-shift-darker-gray;
+}
+
+
+.unl-bg-shift-top-darkest-gray,
+.unl-bg-shift-bottom-darkest-gray {
+  @include mixins.bg-shift-darkest-gray;
+}
+
+
+.unl-bg-shift-top-scarlet,
+.unl-bg-shift-bottom-scarlet {
+  @include mixins.bg-shift-scarlet;
+}
+
+
 // Dots
 [class*='unl-bg-dots-'] { @include mixins.bg-dots; }
 .unl-bg-dots-gray { @include mixins.bg-dots-gray; }

--- a/wdn/templates_6.0/scss/variables/_backgrounds.scss
+++ b/wdn/templates_6.0/scss/variables/_backgrounds.scss
@@ -6,6 +6,7 @@
 @use "sass:color";
 @use './body' as body;
 @use './color-palette' as color_palette;
+@use './sizing' as s;
 
 
 @forward "@dcf/scss/variables/backgrounds" with (
@@ -58,3 +59,7 @@ $bg-color-brand-light-eta: var(--bg-brand-light-eta) !default;
 $bg-color-brand-light-theta-light-mode: color_palette.$lighter-purple !default;   // Light theta brand background-color (light purple) in light mode
 $bg-color-brand-light-theta-dark-mode: color_palette.$dark-purple !default;       // Light theta brand background-color (light purple) in dark mode
 $bg-color-brand-light-theta: var(--bg-brand-light-theta) !default;
+
+
+// Shift size:
+$bg-shift-size: s.$length-em-9;   // Size of transparent region to let existing section background-color show through


### PR DESCRIPTION
Add `linear-gradient`-based `background-image`s, each consisting of a solid background color, hard stop and short, transparent region (at either the top or bottom of the section) to let the existing section `background-color` to show through. These can be used to create the illusion of objects breaking the plane.