### PR TITLE
Fix jQuery library's fake define

### DIFF
--- a/wdn/templates_6.0/js-src/plugins/other/form-validator.js
+++ b/wdn/templates_6.0/js-src/plugins/other/form-validator.js
@@ -56,6 +56,9 @@ async function fakeDefine(jQuery) {
     // Save old define
     const oldDefine = window.define;
     window.define = (deps, factory) => {
+        if (typeof factory !== 'function') {
+            return;
+        }
         factory(jQuery);
     };
     window.define.amd = true;

--- a/wdn/templates_6.0/js-src/plugins/other/jquery-ui.js
+++ b/wdn/templates_6.0/js-src/plugins/other/jquery-ui.js
@@ -45,6 +45,9 @@ async function fakeDefine(jQuery) {
     // Save old define
     const oldDefine = window.define;
     window.define = (deps, factory) => {
+        if (typeof factory !== 'function') {
+            return;
+        }
         factory(jQuery);
     };
     window.define.amd = true;


### PR DESCRIPTION
I was getting an error about factory not being a function. So I updated the code to check if it is a function before calling it as a function.