### PR TITLE
Add `clip-path` mixins/utilities, move `.unl-frame-quad` from "global"

### DIFF
--- a/wdn/templates_6.0/scss/components/_global.scss
+++ b/wdn/templates_6.0/scss/components/_global.scss
@@ -11,11 +11,6 @@
 }
 
 
-.unl-frame-quad {
-  clip-path: polygon(0 0,0 100%,2px 100%,2px 2px,calc(100% - 2px) 2px,calc(100% - 2px) calc(100% - 2px),2px calc(100% - 2px),2px calc(100% - 5px),calc(100% - 5px) calc(100% - 5px),calc(100% - 5px) 5px,5px 5px,5px calc(100% - 5px),2px calc(100% - 5px),2px 100%,100% 100%,100% 0);
-}
-
-
 // TODO: replace with clip-path method?
 .unl-frame-circle {
   position: relative;

--- a/wdn/templates_6.0/scss/mixins/_clip-paths.scss
+++ b/wdn/templates_6.0/scss/mixins/_clip-paths.scss
@@ -1,0 +1,23 @@
+/////////////////////////////
+// CORE / MIXINS / CLIP PATHS
+/////////////////////////////
+
+
+@mixin clip-stripe-top($imp:null) {
+  clip-path: polygon(0 0,100% 0,100% 2px,0 2px,0 5px,100% 5px,100% 100%,0 100%) $imp;
+}
+
+
+@mixin clip-stripe-bottom($imp:null) {
+  clip-path: polygon(0 0,100% 0,100% calc(100% - 5px),0 calc(100% - 5px),0 calc(100% - 2px),100% calc(100% - 2px),100% 100%,0 100%) $imp;
+}
+
+
+@mixin clip-stripe-block($imp:null) {
+  clip-path: polygon(0 0,100% 0,100% 2px,0 2px,0 5px,100% 5px,100% calc(100% - 5px),0 calc(100% - 5px),0 calc(100% - 2px),100% calc(100% - 2px),100% 100%,0 100%) $imp;
+}
+
+
+@mixin clip-frame-quad($imp:null) {
+  clip-path: polygon(0 0,0 100%,2px 100%,2px 2px,calc(100% - 2px) 2px,calc(100% - 2px) calc(100% - 2px),2px calc(100% - 2px),2px calc(100% - 5px),calc(100% - 5px) calc(100% - 5px),calc(100% - 5px) 5px,5px 5px,5px calc(100% - 5px),2px calc(100% - 5px),2px 100%,100% 100%,100% 0) $imp;
+}

--- a/wdn/templates_6.0/scss/mixins/_index.scss
+++ b/wdn/templates_6.0/scss/mixins/_index.scss
@@ -13,6 +13,7 @@
 @forward "./blend-modes";
 @forward "./border-color";
 @forward "./box-shadow";
+@forward "./clip-paths";
 @forward "./colors";
 @forward "./filters";
 @forward "./fonts";

--- a/wdn/templates_6.0/scss/utilities/_clip-paths.scss
+++ b/wdn/templates_6.0/scss/utilities/_clip-paths.scss
@@ -1,0 +1,26 @@
+////////////////////////////////
+// CORE / UTILITIES / CLIP PATHS
+////////////////////////////////
+
+
+@use "../mixins/" as mixins;
+
+
+.unl-clip-stripe-top {
+  @include mixins.clip-stripe-top;
+}
+
+
+.unl-clip-stripe-bottom {
+  @include mixins.clip-stripe-bottom;
+}
+
+
+.unl-clip-stripe-block {
+  @include mixins.clip-stripe-block;
+}
+
+
+.unl-frame-quad {
+  @include mixins.clip-frame-quad;
+}

--- a/wdn/templates_6.0/scss/utilities/_index.scss
+++ b/wdn/templates_6.0/scss/utilities/_index.scss
@@ -16,6 +16,7 @@
   @include meta.load-css("./blend-modes");
   @include meta.load-css("./border-color");
   @include meta.load-css("./box-shadow");
+  @include meta.load-css("./clip-paths");
   @include meta.load-css("./colors");
   @include meta.load-css("./filters");
   @include meta.load-css("./fonts");


### PR DESCRIPTION
- Add `clip-path`-based UNL stripes (as mixins/utilities) for top, bottom and both (`block`) of an element
- Move `.unl-frame-quad` from "components/global" to "utilities/clip-paths"