### PR TITLE
Cache busting

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { defineConfig, loadEnv } from 'vite';
 import eslintPlugin from 'vite-plugin-eslint';
@@ -10,15 +11,28 @@ import wdnSmudge from './vite.wdnSmudgePlugin.js';
 import wdnZipPlugin from './vite.wdnZipPlugin.js';
 import wdnCriticalCSSInjector from './vite.wdnCriticalCSSInjector.js';
 import wdnLayerPolyfill from './vite.wdnLayerPolyfill.js';
+import wdnImportVersion from './vite.wdnImportVersion.js';
 
 export default ({ mode }) => {
     process.env = {...process.env, ...loadEnv(mode, process.cwd(), '')};
 
+    const versionPath = resolve('./VERSION_DEP');
+    if (!existsSync(versionPath)) {
+        this.error(`Version file not found: ${versionPath}`);
+    }
+    const version = readFileSync(versionPath, 'utf8').trim();
+
     // Default plugins which are loaded every time
     const plugins = [
         wdnCleanupPlugin,
-        wdnFinalJsUrlPlugin,
+        wdnCleanupPlugin,
+        wdnFinalJsUrlPlugin({
+            version: version,
+        }),
         wdnLayerPolyfill(),
+        wdnImportVersion({
+            version: version,
+        }),
         wdnCriticalCSSInjector({
             cssFile: './wdn/templates_6.0/css/critical.css',
             targets: [

--- a/vite.wdnFinalJsUrlPlugin.js
+++ b/vite.wdnFinalJsUrlPlugin.js
@@ -1,58 +1,62 @@
 let base = '';
 const placeholders = new Map();
 
-const wdnFinalJsUrlPlugin = {
-    name: 'WDN: Final Url',
-    enforce: 'pre',
+export default function wdnFinalJsUrlPlugin(options = {}) {
+    const {
+        version = '',
+    } = options;
 
-    configResolved(config) {
-        // Vite’s `base` (public path) e.g. '/assets/'
-        base = config.base || '/';
-    },
+    return {
+        name: 'WDN: Final Url',
+        enforce: 'pre',
 
-    async resolveId(source, importer) {
-        if (source.endsWith('?finalUrl')) {
-            const [id] = source.split('?');
-            const resolved = await this.resolve(id, importer, { skipSelf: true });
-            if (resolved) {
-                return `${resolved.id}?finalUrl`;
-            }
-        }
-        return null;
-    },
+        configResolved(config) {
+            // Vite’s `base` (public path) e.g. '/assets/'
+            base = config.base || '/';
+        },
 
-    load(id) {
-        if (id.endsWith('?finalUrl')) {
-            const [realId] = id.split('?');
-            // register chunk; get a numeric ref
-            const ref = this.emitFile({ type: 'chunk', id: realId });
-            // stash it for later
-            placeholders.set(realId, ref);
-            // return a simple string placeholder
-            return `export default "__FINAL_URL__${ref}__";`;
-        }
-        return null;
-    },
-
-    // eslint-disable-next-line
-    async generateBundle(_, bundle) {
-        // for each emitted placeholder…
-        // eslint-disable-next-line
-        for (const [realId, ref] of placeholders) {
-            // lookup the actual filename for this chunk
-            const fileName = this.getFileName(ref);
-            // build the final URL string
-            const url = base + fileName;
-            const pattern = `__FINAL_URL__${ref}__`;
-
-            // replace in every JS chunk
-            for (const chunk of Object.values(bundle)) {
-                if (chunk.type === 'chunk') {
-                    chunk.code = chunk.code.split(pattern).join(url);
+        async resolveId(source, importer) {
+            if (source.endsWith('?finalUrl')) {
+                const [id] = source.split('?');
+                const resolved = await this.resolve(id, importer, { skipSelf: true });
+                if (resolved) {
+                    return `${resolved.id}?finalUrl`;
                 }
             }
-        }
-    },
-};
+            return null;
+        },
 
-export default wdnFinalJsUrlPlugin;
+        load(id) {
+            if (id.endsWith('?finalUrl')) {
+                const [realId] = id.split('?');
+                // register chunk; get a numeric ref
+                const ref = this.emitFile({ type: 'chunk', id: realId });
+                // stash it for later
+                placeholders.set(realId, ref);
+                // return a simple string placeholder
+                return `export default "__FINAL_URL__${ref}__";`;
+            }
+            return null;
+        },
+
+        // eslint-disable-next-line
+        async generateBundle(_, bundle) {
+            // for each emitted placeholder…
+            // eslint-disable-next-line
+            for (const [realId, ref] of placeholders) {
+                // lookup the actual filename for this chunk
+                const fileName = this.getFileName(ref);
+                // build the final URL string
+                const url = `${base}${fileName}?v=${version}`;
+                const pattern = `__FINAL_URL__${ref}__`;
+
+                // replace in every JS chunk
+                for (const chunk of Object.values(bundle)) {
+                    if (chunk.type === 'chunk') {
+                        chunk.code = chunk.code.split(pattern).join(url);
+                    }
+                }
+            }
+        },
+    };
+}

--- a/vite.wdnImportVersion.js
+++ b/vite.wdnImportVersion.js
@@ -1,0 +1,28 @@
+export default function wdnImportVersion(options = {}) {
+    const {
+        version = '',
+    } = options;
+
+    return {
+        name: 'WDN: Import Version',
+        enforce: 'post', // run after Vite transforms
+
+        renderChunk(code, chunk) {
+            // Modify only JS chunks
+            if (!chunk.fileName.endsWith('.js')) {
+                return null;
+            }
+
+            let updated = code;
+
+            const jsFileRegex = new RegExp(/\.js('|"|`)/g);
+            updated = updated.replace(jsFileRegex, `.js?v=${version}$1`);
+
+            const cssFileRegex = new RegExp(/\.css('|"|`)/g);
+            updated = updated.replace(cssFileRegex, `.css?v=${version}$1`);
+
+            return { code: updated, map: null };
+            // Returning null map here tells Rollup to regenerate
+        },
+    };
+}

--- a/wdn/templates_6.0/js-src/components/unl-alert.js
+++ b/wdn/templates_6.0/js-src/components/unl-alert.js
@@ -309,9 +309,9 @@ export default class UNLAlert {
     async #fetchAlertData() {
         try {
 
-            const cacheBuster = `cb=${Date.now()}`;
-            const urlWithCacheBuster = `${this.alertDataUrl}?${cacheBuster}`;
-            await loadJS(urlWithCacheBuster);
+            const dataURL = new URL(this.alertDataUrl);
+            dataURL.searchParams.set('cb', Date.now());
+            await loadJS(dataURL.toString());
             const unlAlertsData = window.unlAlerts.data;
 
             // Check if alert data exists and the page is not in an iframe, then alert the user.


### PR DESCRIPTION
Changes:

- Added new vite plugin for added cache busting version to each import `?v={dep version}`
   - Added cache busting version to all js imports
   - Added cache busting version to CSS imports (loadStyleSheet)
- Update final url vite plugin to also add cache busting version for plugin url constants
- Updated alert to not have invalid URL due to additional parameters