### PR TITLE
Fix form help text color

### DIFF
--- a/wdn/templates_6.0/scss/variables/_forms.scss
+++ b/wdn/templates_6.0/scss/variables/_forms.scss
@@ -3,6 +3,7 @@
 ////////////////////////////
 
 @use './color-palette' as color_palette;
+@use './colors-text' as colors_text;
 
 @forward "@dcf/scss/variables/forms" with (
 
@@ -23,6 +24,7 @@
   $border-color-required-light-mode: transparent,
   $border-color-required-dark-mode: color_palette.$scarlet-shade,
   $color-required-label-light-mode: color_palette.$scarlet,
-  $color-required-label-dark-mode: color_palette.$cream
+  $color-required-label-dark-mode: color_palette.$cream,
+  $color-form-help-dark-mode: colors_text.$color-light-text-dark-mode
 
 );


### PR DESCRIPTION
Form help text color was being set to `$color-dark-gray-dark-mode` or `$light-gray` by default in DCF. So I switched it to be set to `$color-light-text-dark-mode` or `$gray-s1` in the WDN theme