### PR TITLE
Adjust breadcrumbs mobile height

### DIFF
--- a/wdn/templates_6.0/scss/components/_breadcrumbs.scss
+++ b/wdn/templates_6.0/scss/components/_breadcrumbs.scss
@@ -49,7 +49,9 @@
 @include mixins.mq(md, max, width) {
 
   .unl .dcf-breadcrumbs {
-    @include mixins.h-9; // Set height of breadcrumbs in order to hide horizontal scroll bar
+    height: calc(var.$length-em-9 + 1px);
+    // Set height of breadcrumbs in order to hide horizontal scroll bar
+    // + 1px fixes display inconsistencies at different viewport widths
     overflow: hidden; // Hide scroll bars
   }
 


### PR DESCRIPTION
Use `calc` to add `1px` to `height`. This fixes display inconsistencies at different viewport widths where the image or background peaks through underneath the breadcrumbs, like so:

<img width="497" height="263" alt="Screenshot 2025-09-15 at 10 41 22 AM" src="https://github.com/user-attachments/assets/caa9f975-4ac2-4691-bb77-4cc88cdb5eb8" />
