### PR TITLE
Fix Mobile Nav Menu Icon

### DIFF
--- a/wdn/templates_6.0/examples/search.html
+++ b/wdn/templates_6.0/examples/search.html
@@ -54,10 +54,10 @@
         <div id="dcf-nav-toggle-group" class="dcf-nav-toggle-group dcf-pin-bottom dcf-fixed dcf-w-100% dcf-lh-1 dcf-bt-solid dcf-bt-3 unl-bt-scarlet unl-bg-cream hrjs dcf-d-none@print">
           <button class="dcf-nav-toggle-btn dcf-nav-toggle-btn-menu dcf-d-flex dcf-flex-col dcf-ai-center dcf-flex-grow-1 dcf-jc-center dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent unl-scarlet" id="dcf-mobile-toggle-menu" aria-haspopup="true" aria-expanded="false" aria-label="Open menu">
             <svg class="dcf-h-5 dcf-w-5 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">
-              <g id="dcf-nav-toggle-icon-open-menu" class="">
+              <g class="dcf-nav-toggle-icon-open">
                 <path d="M23.5 12.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 4.5H.5C.2 4.5 0 4.3 0 4s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 20.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5z"></path>
               </g>
-              <g id="dcf-nav-toggle-icon-close-menu" class="dcf-d-none">
+              <g class="dcf-nav-toggle-icon-close dcf-d-none">
                 <path d="M20.5 4.2L4.2 20.5c-.2.2-.5.2-.7 0-.2-.2-.2-.5 0-.7L19.8 3.5c.2-.2.5-.2.7 0 .2.2.2.5 0 .7z"></path>
                 <path d="M3.5 4.2l16.3 16.3c.2.2.5.2.7 0s.2-.5 0-.7L4.2 3.5c-.2-.2-.5-.2-.7 0-.2.2-.2.5 0 .7z"></path>
               </g>

--- a/wdn/templates_6.0/examples/search.html
+++ b/wdn/templates_6.0/examples/search.html
@@ -62,7 +62,7 @@
                 <path d="M3.5 4.2l16.3 16.3c.2.2.5.2.7 0s.2-.5 0-.7L4.2 3.5c-.2-.2-.5-.2-.7 0-.2.2-.2.5 0 .7z"></path>
               </g>
             </svg>
-            <span class="dcf-nav-toggle-label-menu dcf-mt-2 dcf-txt-xs">Menu</span>
+            <span class="dcf-nav-toggle-label dcf-mt-2 dcf-txt-xs">Menu</span>
           </button>
           <a class="dcf-nav-toggle-btn dcf-nav-toggle-btn-search dcf-d-flex dcf-flex-col dcf-ai-center dcf-jc-center dcf-flex-grow-1 dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent unl-scarlet" id="dcf-mobile-search-link" href="https://search.unl.edu/" aria-label="Open search">
             <svg class="dcf-h-5 dcf-w-5 dcf-fill-current" aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 24 24">

--- a/wdn/templates_6.0/includes/global/affiliate-nav-toggle-group-1.html
+++ b/wdn/templates_6.0/includes/global/affiliate-nav-toggle-group-1.html
@@ -1,10 +1,10 @@
 <div id="dcf-nav-toggle-group" class="dcf-nav-toggle-group dcf-pin-bottom dcf-fixed dcf-w-100% dcf-bt-solid dcf-bt-2 unl-bg-cream hrjs dcf-d-none@print">
   <button class="dcf-nav-toggle-btn dcf-nav-toggle-btn-menu dcf-d-flex dcf-flex-col dcf-ai-center dcf-flex-grow-1 dcf-jc-center dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent unl-scarlet" id="dcf-mobile-toggle-menu" aria-haspopup="true" aria-expanded="false" aria-label="Open menu">
     <svg class="dcf-txt-sm dcf-h-6 dcf-w-6 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">
-      <g id="dcf-nav-toggle-icon-open-menu" class="">
+      <g class="dcf-nav-toggle-icon-open">
         <path d="M23.5 12.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 4.5H.5C.2 4.5 0 4.3 0 4s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 20.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5z"></path>
       </g>
-      <g id="dcf-nav-toggle-icon-close-menu" class="dcf-d-none">
+      <g class="dcf-nav-toggle-icon-close dcf-d-none">
         <path d="M20.5 4.2L4.2 20.5c-.2.2-.5.2-.7 0-.2-.2-.2-.5 0-.7L19.8 3.5c.2-.2.5-.2.7 0 .2.2.2.5 0 .7z"></path>
         <path d="M3.5 4.2l16.3 16.3c.2.2.5.2.7 0s.2-.5 0-.7L4.2 3.5c-.2-.2-.5-.2-.7 0-.2.2-.2.5 0 .7z"></path>
       </g>

--- a/wdn/templates_6.0/includes/global/affiliate-nav-toggle-group-1.html
+++ b/wdn/templates_6.0/includes/global/affiliate-nav-toggle-group-1.html
@@ -9,5 +9,5 @@
         <path d="M3.5 4.2l16.3 16.3c.2.2.5.2.7 0s.2-.5 0-.7L4.2 3.5c-.2-.2-.5-.2-.7 0-.2.2-.2.5 0 .7z"></path>
       </g>
     </svg>
-    <span class="dcf-nav-toggle-label-menu dcf-mt-1 dcf-txt-2xs">Menu</span>
+    <span class="dcf-nav-toggle-label dcf-mt-1 dcf-txt-2xs">Menu</span>
   </button>

--- a/wdn/templates_6.0/includes/global/nav-toggle-group.html
+++ b/wdn/templates_6.0/includes/global/nav-toggle-group.html
@@ -10,7 +10,7 @@
           <path d="M3.5 4.2l16.3 16.3c.2.2.5.2.7 0s.2-.5 0-.7L4.2 3.5c-.2-.2-.5-.2-.7 0-.2.2-.2.5 0 .7z"></path>
         </g>
       </svg>
-      <span class="dcf-nav-toggle-label-menu dcf-txt-xs dcf-bold unl-ls-1">Menu</span>
+      <span class="dcf-nav-toggle-label dcf-txt-xs dcf-bold unl-ls-1">Menu</span>
     </button>
     <a id="dcf-mobile-search-link" class="dcf-nav-toggle-btn dcf-nav-toggle-btn-search dcf-d-flex dcf-flex-col dcf-ai-center dcf-jc-center dcf-flex-grow-1 dcf-gap-1 dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent unl-cream" href="https://search.unl.edu/">
       <svg class="dcf-h-5 dcf-w-5 dcf-fill-current" aria-hidden="true" focusable="false" height="16" width="16" viewBox="0 0 24 24">

--- a/wdn/templates_6.0/includes/global/nav-toggle-group.html
+++ b/wdn/templates_6.0/includes/global/nav-toggle-group.html
@@ -2,10 +2,10 @@
   <div id="dcf-nav-toggle-group" class="dcf-nav-toggle-group dcf-d-flex dcf-flex-nowrap dcf-lh-1 unl-bg-scarlet">
     <button class="dcf-btn-nav-mobile dcf-nav-toggle-btn dcf-nav-toggle-btn-menu dcf-btn-toggle-dialog dcf-d-flex dcf-flex-col dcf-ai-center dcf-jc-center dcf-flex-grow-1 dcf-gap-1 dcf-h-9 dcf-p-0 dcf-b-0 dcf-bg-transparent unl-cream" id="dcf-mobile-toggle-menu" data-controls="dcf-nav-dialog" data-with-nav-toggle-group="true" data-nav-toggle-label-open="Menu" data-nav-toggle-label-closed="Close" aria-haspopup="true" aria-expanded="false" aria-label="Open menu" disabled>
       <svg class="dcf-h-5 dcf-w-5 dcf-fill-current" aria-hidden="true" focusable="false" width="16" height="16" viewBox="0 0 24 24">
-        <g id="dcf-nav-toggle-icon-open-menu" class="">
+        <g class="dcf-nav-toggle-icon-open">
           <path d="M23.5 12.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 4.5H.5C.2 4.5 0 4.3 0 4s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5zM23.5 20.5H.5c-.3 0-.5-.2-.5-.5s.2-.5.5-.5h23c.3 0 .5.2.5.5s-.2.5-.5.5z"></path>
         </g>
-        <g id="dcf-nav-toggle-icon-close-menu" class="dcf-d-none">
+        <g class="dcf-nav-toggle-icon-close dcf-d-none">
           <path d="M20.5 4.2L4.2 20.5c-.2.2-.5.2-.7 0-.2-.2-.2-.5 0-.7L19.8 3.5c.2-.2.5-.2.7 0 .2.2.2.5 0 .7z"></path>
           <path d="M3.5 4.2l16.3 16.3c.2.2.5.2.7 0s.2-.5 0-.7L4.2 3.5c-.2-.2-.5-.2-.7 0-.2.2-.2.5 0 .7z"></path>
         </g>


### PR DESCRIPTION
The mobile nav menu icons' classes (`dcf-nav-toggle-icon-open` and `dcf-nav-toggle-icon-close`) was changed to an ID at some point. DCF dialog uses those classes to switch the icons from the open to close state.

Changes:

- Reverted mobile menu icon classes