### PR TITLE
Use dynamic viewport units for nav, search and IdM dialogs height

### DIFF
--- a/wdn/templates_6.0/scss/components-js/_idm.scss
+++ b/wdn/templates_6.0/scss/components-js/_idm.scss
@@ -75,7 +75,7 @@
       backdrop-filter: blur(3px);
       background-color: var(--bg-overlay-light);
       bottom: 0;
-      height: 100vh;
+      height: 100dvh;
       position: fixed;
       width: 100%;
       z-index: 998;

--- a/wdn/templates_6.0/scss/components-js/_search.scss
+++ b/wdn/templates_6.0/scss/components-js/_search.scss
@@ -31,7 +31,7 @@
   @include mixins.mq(md, max, width) {
 
     .unl dialog#dcf-search-dialog {
-      height: calc(100vh - var.$length-em-9);
+      height: calc(100dvh - var.$length-em-9);
     }
 
 
@@ -53,7 +53,7 @@
       backdrop-filter: blur(3px);
       background-color: var(--bg-overlay-light);
       bottom: 0;
-      height: 100vh;
+      height: 100dvh;
       position: fixed;
       z-index: 998;
       width: 100%;
@@ -88,7 +88,7 @@
 
 
     .unl .dcf-search-dialog-backdrop:has(.dcf-search-results-wrapper:not(:empty)) {
-      height: 100vh;
+      height: 100dvh;
     }
 
 

--- a/wdn/templates_6.0/scss/components/_nav-menu.scss
+++ b/wdn/templates_6.0/scss/components/_nav-menu.scss
@@ -62,6 +62,14 @@
 }
 
 
+.unl .dcf-nav-menu {
+  backdrop-filter: blur(3px);
+  @include mixins.bg-overlay-light;
+  height: 100vh;
+  width: 100%;
+}
+
+
 .unl .dcf-nav-menu-content {
   @include mixins.bg-scarlet;
 }
@@ -75,13 +83,9 @@
 
 
   .unl .dcf-nav-menu {
-    backdrop-filter: blur(3px);
-    @include mixins.bg-overlay-light;
     bottom: 0;
-    height: 100vh;
     position: fixed;
     transition: opacity var.$transition-duration-fade-in var.$transition-timing-fn-fade-in, visibility 0ms .4s;
-    width: 100%;
     z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
 
@@ -164,12 +168,8 @@
 
 
   .unl .dcf-nav-menu {
-    backdrop-filter: blur(3px);
-    @include mixins.bg-overlay-light;
-    height: 100vh;
     position: relative;
     top: 0;
-    width: 100%;
     z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
 

--- a/wdn/templates_6.0/scss/components/_nav-menu.scss
+++ b/wdn/templates_6.0/scss/components/_nav-menu.scss
@@ -79,11 +79,8 @@
     @include mixins.bg-overlay-light;
     bottom: 0;
     height: 100vh;
-    // opacity: 0;
-    // pointer-events: none;
     position: fixed;
     transition: opacity var.$transition-duration-fade-in var.$transition-timing-fn-fade-in, visibility 0ms .4s;
-    // visibility: hidden;
     width: 100%;
     z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
@@ -102,7 +99,6 @@
     bottom: calc(#{var.$height-mobile-toolbar} - 1px);
     opacity: 0;
     position: fixed;
-    // transform-origin: bottom;
     transition: opacity var.$transition-duration-fade-out var.$transition-timing-fn-fade-out;
   }
 
@@ -170,43 +166,22 @@
   .unl .dcf-nav-menu {
     backdrop-filter: blur(3px);
     @include mixins.bg-overlay-light;
-    // bottom: #{var.$height-mobile-toolbar};
     height: 100vh;
-    // opacity: 0;
-    // pointer-events: none;
-    // position: fixed;
     position: relative;
     top: 0;
-    // transition: opacity var.$transition-duration-fade-out var.$transition-timing-fn-fade-out;
-    // transition: opacity var.$transition-duration-fade-in var.$transition-timing-fn-fade-in, visibility 0ms .4s;
-    // visibility: hidden;
     width: 100%;
     z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
 
 
   .unl .dcf-nav-menu-content {
-    // @include mixins.bg-scarlet;
-    // max-height: 56vh;
-    // @include mixins.overflow-y-auto;
     overflow-y: auto;
-    // padding-left: var.$length-vw-2;
-    // padding-right: var.$length-vw-2;
     position: fixed;
-    // transform-origin: top;
   }
 
 
   .unl .dcf-nav-menu-content-child {
-    // --mask-height: 1.78em;
-    // max-height: 56vh;
-    // mask-image: linear-gradient(to bottom,
-    //   rgba(0, 0, 0, 0),
-    //   rgba(0, 0, 0, 1) var(--mask-height),
-    //   rgba(0, 0, 0, 1) calc(100% - var(--mask-height)),
-    //   rgba(0, 0, 0, 0));
     overflow-y: auto;
-    // padding-block: var(--mask-height);
     padding: 0 var.$length-vw-2 var.$length-em-6;
   }
 
@@ -229,7 +204,6 @@
 
   .unl .dcf-nav-local ul ul {
     grid-row: 2 / 3;
-    // @include mixins.pb-7;
     width: 100%;
   }
 

--- a/wdn/templates_6.0/scss/components/_nav-menu.scss
+++ b/wdn/templates_6.0/scss/components/_nav-menu.scss
@@ -65,7 +65,7 @@
 .unl .dcf-nav-menu {
   backdrop-filter: blur(3px);
   @include mixins.bg-overlay-light;
-  height: 100vh;
+  height: 100dvh;
   width: 100%;
 }
 

--- a/wdn/templates_6.0/scss/components/_nav-menu.scss
+++ b/wdn/templates_6.0/scss/components/_nav-menu.scss
@@ -85,31 +85,12 @@
   .unl .dcf-nav-menu {
     bottom: 0;
     position: fixed;
-    transition: opacity var.$transition-duration-fade-in var.$transition-timing-fn-fade-in, visibility 0ms .4s;
-    z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
-  }
-
-
-  // Open when parent model is open
-  .unl .dcf-nav-menu.dcf-modal-is-open {
-  	opacity: 1;
-  	pointer-events: auto;
-    transition: opacity var.$transition-duration-fade-in var.$transition-timing-fn-fade-in;
-  	visibility: visible;
   }
 
 
   .unl .dcf-nav-menu-content {
     bottom: calc(#{var.$height-mobile-toolbar} - 1px);
-    opacity: 0;
     position: fixed;
-    transition: opacity var.$transition-duration-fade-out var.$transition-timing-fn-fade-out;
-  }
-
-
-  .unl .dcf-dialog-is-open .dcf-nav-menu-content {
-    opacity: 1;
-    transition: opacity var.$transition-duration-fade-in var.$transition-timing-fn-fade-in;
   }
 
 
@@ -170,7 +151,6 @@
   .unl .dcf-nav-menu {
     position: relative;
     top: 0;
-    z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
 
 


### PR DESCRIPTION
[`100dvh`](https://www.bram.us/2021/07/08/the-large-small-and-dynamic-viewports/#dynamic-viewport) fixes the [“100vh in Safari on iOS” issue](https://www.bram.us/2020/05/06/100vh-in-safari-on-ios/).