### PR TITLE
Replace stagger animations Sass loop with `sibling-index()`

### DIFF
--- a/wdn/templates_6.0/scss/utilities/_animations.scss
+++ b/wdn/templates_6.0/scss/utilities/_animations.scss
@@ -20,10 +20,26 @@
 
 
   // Stagger scroll FX
-  @for $i from 0 through 48 {
-    .unl-scroll-trigger-stagger .unl-scroll-trigger-container:nth-of-type(#{$i}) [class*="unl-scroll-fx-"] {
-      transition-delay: ($i * var.$transition-delay-scroll-fx-stagger);
+  // @supports checks whether the browser understands a specific declaration.
+  // sibling-index() returns a number.
+  // z-index accepts a number value, so it’s a safe property to test with.
+  // If the browser doesn't recognize sibling-index(), the whole declaration becomes invalid and the @supports block will fail.
+  @supports (z-index: sibling-index()) {
+
+    @property --stagger-index {
+      syntax: "<integer>";
+      inherits: true;
+      initial-value: 0;
     }
+
+    .unl-scroll-trigger-stagger .unl-scroll-trigger-container {
+      --stagger-index: sibling-index();
+    }
+
+    .unl-scroll-trigger-stagger .unl-scroll-trigger-container [class*="unl-scroll-fx-"] {
+      transition-delay: calc(var(--stagger-index) * #{var.$transition-delay-scroll-fx-stagger});
+    }
+
   }
 
 


### PR DESCRIPTION
Rather than define an arbitrary upper limit on the number of items that can be staggered, use `sibling-index()` to apply a `transition-delay` to all siblings no matter the number. Browser support is currently at about [70%](https://caniuse.com/wf-sibling-count) (older browsers and Firefox being the outliers), which is good enough for a feature that's a _nice-to-have_ not a _need-to-have_. Removing the Sass loop cuts about 5.5kb of CSS.