### PR TITLE
Added vite plugin to help us test critical css

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "vite build",
     "build-watch": "vite build --watch",
     "build-smudge": "vite build -- --smudge",
+    "build-criticalCSSTest": "vite build -- --criticalCSSTest",
     "preview": "vite preview",
     "lint-js": "eslint wdn/templates_6.1/js-src/**/*.js"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ import wdnCriticalCSSInjector from './vite.wdnCriticalCSSInjector.js';
 import wdnLayerPolyfill from './vite.wdnLayerPolyfill.js';
 import wdnImportVersion from './vite.wdnImportVersion.js';
 import wdnMockBannerInjector from './vite.wdnMockBannerInjector.js';
+import wdnCriticalCSSTest from './vite.wdnCriticalCSSTest.js';
 
 export default ({ mode }) => {
     process.env = {...process.env, ...loadEnv(mode, process.cwd(), '')};
@@ -50,6 +51,17 @@ export default ({ mode }) => {
         //   since if we have a linting error it won't build
         plugins.push(
             eslintPlugin(),
+        );
+    }
+
+    if (process.argv.includes('--criticalCSSTest')) {
+        plugins.push(
+            wdnCriticalCSSTest({
+                targets: [
+                    './wdn/templates_6.1/css/main.css',
+                    './wdn/templates_6.1/js/auto-loader.js',
+                ],
+            }),
         );
     }
 

--- a/vite.wdnCriticalCSSTest.js
+++ b/vite.wdnCriticalCSSTest.js
@@ -1,0 +1,21 @@
+import { existsSync, writeFileSync } from 'fs';
+import path from 'path';
+
+export default function wdnCriticalCSSTest({ targets }) {
+    return {
+        name: 'WDN: Critical CSS Testing',
+        apply: 'build',
+        enforce: 'post',
+        async closeBundle() {
+            targets.forEach(targetFile => {
+                const targetPath = path.resolve(targetFile);
+                if (!existsSync(targetPath)) {
+                    console.warn(`Target file not found: ${targetPath}`);
+                    return;
+                }
+
+                writeFileSync(targetPath, '', 'utf-8');
+            });
+        },
+    };
+}


### PR DESCRIPTION
Changes:

- Added a vite plugin and build command to remove contents of main.css and auto-loader.js allowing us to view the page with only the critical.css loaded