### PR TITLE
Add dark cream variables, mixins and utilities

### DIFF
--- a/wdn/templates_6.1/scss/generic/_root.scss
+++ b/wdn/templates_6.1/scss/generic/_root.scss
@@ -13,6 +13,7 @@
   --bg-badge: #{var.$bg-color-badge-light-mode};
   --bg-body: #{var.$bg-color-body-light-mode};
   --bg-brand-alpha: #{var.$bg-color-brand-alpha-light-mode};
+  --bg-brand-beta-shade: #{var.$bg-color-brand-beta-shade-light-mode};
   --bg-brand-zeta: #{var.$bg-color-brand-zeta-light-mode};
   --bg-brand-eta: #{var.$bg-color-brand-eta-light-mode};
   --bg-brand-theta: #{var.$bg-color-brand-theta-light-mode};
@@ -176,6 +177,7 @@
     --bg-badge: #{var.$bg-color-badge-dark-mode};
     --bg-body: #{var.$bg-color-body-dark-mode};
     --bg-brand-alpha: #{var.$bg-color-brand-alpha-dark-mode};
+    --bg-brand-beta-shade: #{var.$bg-color-brand-beta-shade-dark-mode};
     --bg-brand-zeta: #{var.$bg-color-brand-zeta-dark-mode};
     --bg-brand-eta: #{var.$bg-color-brand-eta-dark-mode};
     --bg-brand-theta: #{var.$bg-color-brand-theta-dark-mode};

--- a/wdn/templates_6.1/scss/mixins/_background-colors.scss
+++ b/wdn/templates_6.1/scss/mixins/_background-colors.scss
@@ -13,6 +13,8 @@
 // Cream
 @mixin bg-cream($imp:null) { background-color: var.$bg-color-body $imp; }
 @mixin bg-cream-at-dark($imp:null) { background-color: var.$cream $imp; }
+@mixin bg-dark-cream($imp:null) { background-color: var.$bg-color-brand-beta-shade $imp; }
+@mixin bg-dark-cream-at-dark($imp:null) { background-color: var.$cream-shade $imp; }
 
 
 // Gray

--- a/wdn/templates_6.1/scss/utilities/_background-colors.scss
+++ b/wdn/templates_6.1/scss/utilities/_background-colors.scss
@@ -14,6 +14,7 @@
 
   // Cream
   .unl-bg-cream { @include mixins.bg-cream; }
+  .unl-bg-dark-cream { @include mixins.bg-dark-cream; }
 
 
   // Gray
@@ -58,6 +59,7 @@
 
   // Cream
   .unl-bg-cream\@dark { @include mixins.bg-cream-at-dark; }
+  .unl-bg-dark-cream\@dark { @include mixins.bg-dark-cream-at-dark; }
 
 
   // Gray

--- a/wdn/templates_6.1/scss/variables/_backgrounds.scss
+++ b/wdn/templates_6.1/scss/variables/_backgrounds.scss
@@ -37,6 +37,10 @@ $bg-color-brand-alpha-light-mode: color_palette.$scarlet !default;              
 $bg-color-brand-alpha-dark-mode: color_palette.$scarlet !default;                 // Alpha brand background-color (scarlet) in dark mode
 $bg-color-brand-alpha: var(--bg-brand-alpha) !default;
 
+$bg-color-brand-beta-shade-light-mode: color_palette.$cream-shade !default;       // Beta shade brand background-color (scarlet) in light mode
+$bg-color-brand-beta-shade-dark-mode: color_palette.$darker-gray !default;        // Beta shade brand background-color (scarlet) in dark mode
+$bg-color-brand-beta-shade: var(--bg-brand-beta-shade) !default;
+
 $bg-color-brand-zeta-light-mode: color_palette.$green !default;                   // Zeta brand background-color (green) in light mode
 $bg-color-brand-zeta-dark-mode: color_palette.$dark-green !default;               // Zeta brand background-color (green) in dark mode
 $bg-color-brand-zeta: var(--bg-brand-zeta) !default;

--- a/wdn/templates_6.1/scss/variables/_color-palette.scss
+++ b/wdn/templates_6.1/scss/variables/_color-palette.scss
@@ -60,24 +60,24 @@ $dark-purple: #7f2a70;
 
 // NEUTRALS
 // Mix cream and gray brand colors for base color
-$mix-cream-gray: color.mix($cream, $gray);            // #e3e3e2
+$mix-cream-gray: color.mix($cream, $gray);													// #e3e3e2
 
-$lightest-gray: color.adjust($mix-cream-gray, $lightness: 7.5%); // #f6f6f5;
-$lighter-gray: color.adjust($mix-cream-gray, $lightness: 3.2%);  // #ebebea
-$light-gray: $mix-cream-gray;                   // #e3e3e2
+$lightest-gray: color.adjust($mix-cream-gray, $lightness: 7.5%);		// #f6f6f5;
+$lighter-gray: color.adjust($mix-cream-gray, $lightness: 3.2%);			// #ebebea
+$light-gray: $mix-cream-gray;                   										// #e3e3e2
 
-$gray-s1: color.adjust($mix-cream-gray, $lightness: -25%);         // #a4a4a1
+$gray-s1: color.adjust($mix-cream-gray, $lightness: -25%);					// #a4a4a1
 
-$dark-gray: color.adjust($mix-cream-gray, $lightness: -47.5%);     // #6b6b68
+$dark-gray: color.adjust($mix-cream-gray, $lightness: -47.5%);			// #6b6b68
 
-$darker-gray: color.adjust($mix-cream-gray, $lightness: -63.3%);   // #424240
-$darker-gray-s1: color.adjust($mix-cream-gray, $lightness: -67%);  // #393937
-$darker-gray-s2: color.adjust($mix-cream-gray, $lightness: -69%);  // #333332
-$darker-gray-s3: color.adjust($mix-cream-gray, $lightness: -71%);  // #2e2e2d
-$darker-gray-s4: color.adjust($mix-cream-gray, $lightness: -73%);  // #292928
+$darker-gray: color.adjust($mix-cream-gray, $lightness: -63.3%);		// #424240
+$darker-gray-s1: color.adjust($mix-cream-gray, $lightness: -67%);		// #393937
+$darker-gray-s2: color.adjust($mix-cream-gray, $lightness: -69%);		// #333332
+$darker-gray-s3: color.adjust($mix-cream-gray, $lightness: -71%);		// #2e2e2d
+$darker-gray-s4: color.adjust($mix-cream-gray, $lightness: -73%);		// #292928
 
-$darkest-gray: color.adjust($mix-cream-gray, $lightness: -75%);    // #242423
-$darkest-gray-s1: color.adjust($mix-cream-gray, $lightness: -77%); // #1f1f1e
+$darkest-gray: color.adjust($mix-cream-gray, $lightness: -75%);			// #242423
+$darkest-gray-s1: color.adjust($mix-cream-gray, $lightness: -77%);	// #1f1f1e
 
 
 @forward "@dcf/scss/variables/color-palette" with (

--- a/wdn/templates_6.1/scss/variables/_color-palette.scss
+++ b/wdn/templates_6.1/scss/variables/_color-palette.scss
@@ -18,6 +18,8 @@ $gray: $brand-gamma;
 $scarlet-shade: color.scale($scarlet, $saturation: 10%, $lightness: -24%);
 $scarlet-tint: #f6e6e3;
 
+$cream-shade: #f5f1e7;
+
 
 // SECONDARY BRAND
 $brand-delta: #001738;    // Navy


### PR DESCRIPTION
- Add `$cream-shade` Sass color variable
- Add `--bg-brand-beta-shade` CSS custom properties (variables)
- Add backgrounds variables (`$bg-color-brand-beta-shade-light-mode`, `$bg-color-brand-beta-shade-dark-mode`, `$bg-color-brand-beta-shade`)
- Add dark-cream background mixins (`bg-dark-cream`, `bg-dark-cream-at-dark`)
- Add dark-cream background utilities (`.unl-bg-dark-cream`, `.unl-bg-dark-cream@dark`)
- Adjust comments (no change to output)