### PR TITLE
Update footer list styles

### DIFF
--- a/wdn/templates_6.1/includes/global/footer-global-3-big.html
+++ b/wdn/templates_6.1/includes/global/footer-global-3-big.html
@@ -1,7 +1,7 @@
 <div class="unl-big-footer dcf-relative dcf-z-1 dcf-wrapper dcf-pt-9">
   <div class="unl-big-footer-social dcf-d-flex dcf-flex-wrap dcf-ai-center dcf-col-gap-4 dcf-row-gap-1 dcf-d-none@print">
     <h2 class="dcf-mb-0">Connect with Us</h2>
-    <ul class="unl-big-footer-social-list dcf-d-flex dcf-flex-wrap dcf-ai-center dcf-col-gap-5 dcf-row-gap-4 dcf-mb-0">
+    <ul class="unl-big-footer-social-list dcf-d-flex dcf-flex-wrap dcf-ai-center dcf-col-gap-5 dcf-row-gap-4 dcf-mb-0" role="list">
       <li class="dcf-mb-0">
         <a class="dcf-d-block dcf-h-6 dcf-w-6" href="https://www.facebook.com/UNLincoln" aria-label="Facebook">
           <svg class="dcf-h-100% dcf-w-100% dcf-fill-current" focusable="false" height="16" width="16" viewBox="0 0 48 48">

--- a/wdn/templates_6.1/scss/components/_footer.scss
+++ b/wdn/templates_6.1/scss/components/_footer.scss
@@ -40,8 +40,8 @@
 }
 
 
-.unl .dcf-footer dl,
-.unl .dcf-footer ul {
+.unl .dcf-footer-groups dl,
+.unl .dcf-footer-groups ul {
   list-style-type: "";
   padding-left: 0;
 }


### PR DESCRIPTION
- Add `role=“list”` to “Herbie” footer social media list (Safari renders the list `:marker`s, throwing off the centered vertical alignment)
- Narrow specificity of footer list styles to footer groups. We don't want the footer group list styles to conflict with the social media list styles.

Pairs with [DCF 623](https://github.com/digitalcampusframework/dcf/pull/623)